### PR TITLE
Improve layout and styling

### DIFF
--- a/Confidential_Computing_Concepts.md
+++ b/Confidential_Computing_Concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Confidential Computing Concepts
-layout: page
+layout: default
 ---
 
 # Confidential Computing Concepts

--- a/Kata_Containers.md
+++ b/Kata_Containers.md
@@ -1,6 +1,6 @@
 ---
 title: Kata Containers
-layout: page
+layout: default
 ---
 
 # Kata Containers

--- a/Policy_Generation.md
+++ b/Policy_Generation.md
@@ -1,6 +1,6 @@
 ---
 title: Open Policy Agent
-layout: page
+layout: default
 ---
 
 # Open Policy Agent

--- a/Scratch.md
+++ b/Scratch.md
@@ -1,6 +1,6 @@
 ---
 title: Scratch
-layout: page
+layout: default
 ---
 
 https://www.youtube.com/watch?v=YIQi2geM5ys

--- a/_config.yml
+++ b/_config.yml
@@ -2,5 +2,7 @@ title: Confidential Computing Notes
 markdown: kramdown
 kramdown:
   input: GFM
-theme: minima
+remote_theme: pages-themes/cayman@v0.2.0
+plugins:
+  - jekyll-remote-theme
 permalink: pretty

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,47 @@
+---
+---
+@import "{{ site.theme }}";
+
+/* Custom styles */
+body {
+  font-family: "Segoe UI", Arial, sans-serif;
+  background-color: #f8f9fa;
+}
+
+main {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.page-content {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.notes-section {
+  margin-bottom: 2rem;
+}
+
+.notes-list {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.notes-list a {
+  display: block;
+  background: #fff;
+  padding: 0.75rem;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-decoration: none;
+}
+
+.notes-list a:hover {
+  background: #f0f0f0;
+}
+

--- a/cloud_fundamentals.md
+++ b/cloud_fundamentals.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Fundamentals
-layout: page
+layout: default
 ---
 
 ## Autoscaling

--- a/confidential_containers.md
+++ b/confidential_containers.md
@@ -1,4 +1,4 @@
 ---
 title: Confidential Containers
-layout: page
+layout: default
 ---

--- a/containers.md
+++ b/containers.md
@@ -1,6 +1,6 @@
 ---
 title: Containers
-layout: page
+layout: default
 ---
 
 # Containers

--- a/encrypted_filesystem.md
+++ b/encrypted_filesystem.md
@@ -1,6 +1,6 @@
 ---
 title: Encrypted Filesystem
-layout: page
+layout: default
 ---
 
 # Foundations

--- a/grpc.md
+++ b/grpc.md
@@ -1,6 +1,6 @@
 ---
 title: GRPC
-layout: page
+layout: default
 ---
 
 # GRPC

--- a/index.md
+++ b/index.md
@@ -6,17 +6,30 @@ title: Confidential Computing Notes
 Welcome! This site collects my notes on confidential computing topics.
 Select a page below to read more.
 
-## Notes
+## Core Concepts {#core-concepts}
+<ul class="notes-list notes-section">
+  <li><a href="Confidential_Computing_Concepts/">Confidential Computing Concepts</a></li>
+  <li><a href="cloud_fundamentals/">Cloud Fundamentals</a></li>
+  <li><a href="sgx/">SGX</a></li>
+  <li><a href="secure_key_release/">Secure Key Release</a></li>
+</ul>
 
-- [Confidential Computing Concepts](Confidential_Computing_Concepts/)
-- [Kata Containers](Kata_Containers/)
-- [Open Policy Agent](Policy_Generation/)
-- [Containers](containers/)
-- [Encrypted Filesystem](encrypted_filesystem/)
-- [gRPC](grpc/)
-- [Kubernetes](kubernetes/)
-- [Secure Key Release](secure_key_release/)
-- [SGX](sgx/)
-- [Cloud Fundamentals](cloud_fundamentals/)
-- [Scratch](Scratch/)
-- [Confidential Containers](confidential_containers/)
+## Container Technologies {#container-tech}
+<ul class="notes-list notes-section">
+  <li><a href="containers/">Containers</a></li>
+  <li><a href="Kata_Containers/">Kata Containers</a></li>
+  <li><a href="confidential_containers/">Confidential Containers</a></li>
+  <li><a href="kubernetes/">Kubernetes</a></li>
+</ul>
+
+## Tools & Frameworks {#tools}
+<ul class="notes-list notes-section">
+  <li><a href="Policy_Generation/">Open Policy Agent</a></li>
+  <li><a href="grpc/">gRPC</a></li>
+  <li><a href="encrypted_filesystem/">Encrypted Filesystem</a></li>
+</ul>
+
+## Miscellaneous {#misc}
+<ul class="notes-list notes-section">
+  <li><a href="Scratch/">Scratch</a></li>
+</ul>

--- a/kubernetes.md
+++ b/kubernetes.md
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes
-layout: page
+layout: default
 ---
 
 https://eksclustergames.com/challenge/2

--- a/secure_key_release.md
+++ b/secure_key_release.md
@@ -1,6 +1,6 @@
 ---
 title: Secure Key Release
-layout: page
+layout: default
 ---
 
 # Secure Key Release

--- a/sgx.md
+++ b/sgx.md
@@ -1,6 +1,6 @@
 ---
 title: SGX
-layout: page
+layout: default
 ---
 
 After giving this some additional thought, I am not entirely convinced that running an existing application, like the one from my scenario, in a containerized SGX-powered wrapper is a wise idea. Let me explain.


### PR DESCRIPTION
## Summary
- load the Cayman theme via jekyll-remote-theme plugin
- organize the notes on the homepage by category
- style card grid and tighten page layout
- use the default layout for each page so the theme styles apply

## Testing
- `git status --short`
