### PR TITLE
Add intros for containers and OPA docs

### DIFF
--- a/docs/containers/confidential-containers.md
+++ b/docs/containers/confidential-containers.md
@@ -2,3 +2,33 @@
 title: Confidential Containers
 layout: default
 ---
+
+# Confidential Containers
+
+Confidential Containers extend familiar container workflows with hardware-based
+protection for data **in use**. Instead of running directly on a shared host
+kernel, each container—or group of containers—executes inside its own
+lightweight virtual machine backed by a Trusted Execution Environment (TEE).
+This ensures the container's memory is encrypted and isolated from the host
+operating system and hypervisor, thwarting snooping by even highly privileged
+attackers.
+
+By combining the portability of containers with the security of confidential
+computing, platform operators can offer stronger guarantees around privacy and
+integrity. Remote attestation allows workloads to prove they are running in an
+approved environment before secrets or keys are released. The result is a
+familiar container experience with defense-in-depth protections well suited for
+sensitive or multi-tenant scenarios.
+
+## Key Building Blocks
+
+* **Hardware isolation** – Technologies such as AMD SEV-SNP and Intel TDX
+  encrypt guest memory and provide attestation reports that prove the VM's
+  integrity.
+* **Container runtimes** – Projects like Kata Containers and the `cc-runtime`
+  launch pods inside small VMs to take advantage of the underlying TEE
+  capabilities.
+* **Policy enforcement** – Integrations with tools like Open Policy Agent (OPA)
+  let operators define fine-grained rules for what a confidential pod may do
+  once running inside the TEE boundary.
+

--- a/docs/tools/open-policy-agent.md
+++ b/docs/tools/open-policy-agent.md
@@ -6,3 +6,29 @@ layout: default
 # Open Policy Agent
 > "Treat policy as a separate concern....just like DB, messaging, monitoring, logging, orchestration, CI/CD ..." - Torin Sandall, Co-Creator, OPA
 
+# Introduction
+
+Open Policy Agent (OPA) is an open source, general‑purpose policy engine. Instead
+of baking authorization or configuration rules directly into your
+applications, you define them in a high‑level declarative language called Rego
+and let OPA evaluate those policies at runtime. OPA can run as a sidecar,
+as a daemon, or be embedded as a library, giving you flexibility in how policies
+are deployed and updated.
+
+Separating policy from application logic means you can change or audit rules
+without rebuilding your services. A single OPA instance can answer a variety of
+questions: "Is this Kubernetes resource allowed?", "Does this user have access to
+the API?", or "Is this infrastructure configuration compliant?". Because Rego is
+data-driven, policy updates are just another file change—no need to redeploy the
+service itself.
+
+## Typical Use Cases
+
+* **Kubernetes Admission Control** – Integrations such as Gatekeeper rely on OPA
+  to validate resource manifests before they are persisted to the cluster.
+* **API Authorization** – Microservices can query OPA to check whether a user is
+  permitted to invoke a particular endpoint or action.
+* **Configuration Validation** – CI/CD pipelines often execute OPA policies to
+  ensure infrastructure-as-code or container images conform to organizational
+  standards.
+


### PR DESCRIPTION
## Summary
- add an overview of confidential containers
- provide an introduction and typical use cases for Open Policy Agent

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*