### PR TITLE
Add gitignore for Jekyll and OS artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Jekyll build artifacts
+_site/
+.sass-cache/
+.bundle/
+
+# Operating system files
+.DS_Store


### PR DESCRIPTION
## Summary
- avoid committing OS artifacts like `.DS_Store`
- ignore common Jekyll build directories

## Testing
- `git status --short`