### PR TITLE
Add simple table of contents

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -54,4 +54,18 @@ section h2      { font-size:1.5rem; margin-bottom:1rem;
   section h2          { border-bottom-color:#30363d; }
   .card-grid a,
   .notes-list a       { background:#161b22; color:#58a6ff; }
+  #markdown-toc       { border-left-color:#30363d; }
+}
+/* ─────────────────── Table of contents ─────────────────── */
+#markdown-toc {
+  margin:1rem 0 2rem;
+  padding-left:1rem;
+  border-left:4px solid #e1e4e8;
+}
+#markdown-toc ul {
+  list-style:none;
+  padding-left:1rem;
+}
+#markdown-toc a {
+  text-decoration:none;
 }

--- a/docs/containers/confidential-containers.md
+++ b/docs/containers/confidential-containers.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 # Confidential Containers
 
 Confidential Containers extend familiar container workflows with hardware-based

--- a/docs/containers/containers.md
+++ b/docs/containers/containers.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 # Containers
 
 ## Open Container Initiative (OCI)

--- a/docs/containers/kata-containers.md
+++ b/docs/containers/kata-containers.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 # Kata Containers
 
 **Kata Containers** is an open-source project providing lightweight virtual machines (VMs) with the agility and speed of traditional containers. By merging hardware virtualization and containerization, Kata offers stronger isolation while retaining near-native performance. It originated from two projects:

--- a/docs/containers/kubernetes.md
+++ b/docs/containers/kubernetes.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 https://eksclustergames.com/challenge/2
 https://www.youtube.com/watch?v=Ki1J2pxAHdQ&list=PLBexUsYDijawgCdEqEDBj3cUCovUS1MM5&index=4
 https://www.youtube.com/playlist?list=PLBexUsYDijaz09nH8BVPmPio_16V115i4

--- a/docs/core/confidential-computing-concepts.md
+++ b/docs/core/confidential-computing-concepts.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 # Confidential Computing Concepts
 **Confidential computing** refers to technologies and practices that isolate and protect data during processing, preventing unauthorized access—even by the owner of the hardware or a **cloud service provider** (CSP). This is primarily achieved using **trusted execution environments** (TEEs) and associated security mechanisms such as attestation, secure boot, and robust key management.
 

--- a/docs/core/encrypted-filesystem.md
+++ b/docs/core/encrypted-filesystem.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 # Foundations
 
 A **filesystem** is responsible for organizing, storing, and retrieving data on a storage device, like a hard drive or SSD. It manages files and directories and controls how data is stored and retrieved. The goal of a cryptographic file system is to secure data stored on disk through encryption. Without the correct encryption key, the data is unreadable to unauthorized users. 

--- a/docs/core/secure-key-release.md
+++ b/docs/core/secure-key-release.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 # Secure Key Release
 ## Key Management System (KMS)
 A KMS is a piece of software that performs cryptographic operations (such as encryption and managing private keys). It is usually embedded inside a secure hardware component or inside hardware security modules (also referred to as HSMs).

--- a/docs/core/sgx.md
+++ b/docs/core/sgx.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 After giving this some additional thought, I am not entirely convinced that running an existing application, like the one from my scenario, in a containerized SGX-powered wrapper is a wise idea. Let me explain.
 
 The solutions I’ve encountered typically employ something akin to a library OS, which is an operating system implemented as a library. This setup allows your application to make Linux system calls as usual. However, behind the scenes, the library OS intercepts those calls and executes its own implementation of the syscall. Running the syscall inside an SGX enclave is not always possible or does not always behave the same as against a ‘normal’ Linux kernel, which is why they have their own specific implementation that works inside of SGX. For instance, working with networking syscalls within SGX is quite tricky and often requires unconventional methods. So, unless you are prepared to invest the effort to port and extensively test your application under various constraints, it appears uncertain whether an existing (legacy) app will behave as expected.

--- a/docs/misc/cloud-fundamentals.md
+++ b/docs/misc/cloud-fundamentals.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 ## Autoscaling
 Autoscaling is the process of dynamically allocating and deallocating resources to match an application’s performance requirements.
 The goal is to maintain desired performance levels and meet SLAs while minimizing cost. There are two ways to scale:

--- a/docs/misc/scratch.md
+++ b/docs/misc/scratch.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 https://www.youtube.com/watch?v=YIQi2geM5ys
 https://phala.network/posts/GPU-TEEs-is-Alive-on-OpenRouter
 https://arxiv.org/pdf/2504.21518

--- a/docs/tools/grpc.md
+++ b/docs/tools/grpc.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 # GRPC
 # Remote Procedure Calls (RPC)
 Remote Procedure Calls (RPC) let you write code that appears to call functions locally but actually runs those functions on remote machines. The RPC layer handles all the network messaging and data conversion so that you, the programmer, can pretend it’s all just a simple local function call.

--- a/docs/tools/open-policy-agent.md
+++ b/docs/tools/open-policy-agent.md
@@ -5,6 +5,10 @@ layout: default
 
 [← Back to Main Page]({{ "/" | relative_url }})
 
+* TOC
+{:toc}
+
+
 # Open Policy Agent
 > "Treat policy as a separate concern....just like DB, messaging, monitoring, logging, orchestration, CI/CD ..." - Torin Sandall, Co-Creator, OPA
 


### PR DESCRIPTION
## Summary
- add a CSS rule for table of contents
- include `* TOC` directive on every page so kramdown builds navigation

## Testing
- `git status --short`