### PR TITLE
Add search exclusion for scratch notes

### DIFF
--- a/docs/misc/scratch.md
+++ b/docs/misc/scratch.md
@@ -1,6 +1,7 @@
 ---
 title: Scratch
 layout: default
+search_exclude: true
 ---
 
 [← Back to Main Page]({{ "/" | relative_url }})


### PR DESCRIPTION
## Summary
- keep scratch notes out of site search results

## Testing
- `git status --short`