### PR TITLE
Migrate to just-the-docs theme and restructure docs

### DIFF
--- a/docs/core/live-migration.md
+++ b/docs/core/live-migration.md
@@ -127,14 +127,15 @@ Live migration isn't the only option for handling a maintenance event. A cloud p
 
 A separate **restart behavior** controls whether a terminated VM automatically comes back up, or stays down until an operator restarts it. During a brownout, workloads may see a short dip in performance — terminate-and-restart avoids the dip at the cost of a hard interruption, so the choice depends on whether the app prefers degraded-but-continuous or clean-but-offline.
 
-## What can't live-migrate
+## What's hard to migrate live
 
-Not every workload can move while running. Two common cases:
+The algorithm above works because a VM's state — guest memory, CPU registers, a few device queues — can be captured, copied, and reconstituted on another host. State that doesn't fit that model is where live migration gets hard or impossible:
 
-- **GPU-attached VMs** — the GPU state is hard to snapshot and transfer live, so these VMs are typically set to terminate. The platform instead gives advance notice (on the order of tens of minutes) before the maintenance event so the workload can checkpoint or drain gracefully.
-- **Preemptible / spot instances** — these trade availability for price and are always set to terminate on any disruption. Live migration is simply not offered.
+- **Passthrough devices** — when a VM is given direct access to a physical device (GPU, FPGA, SR-IOV NIC, etc.), the device's internal state lives in hardware, not in memory the hypervisor controls. There's no clean way to snapshot "what the GPU was in the middle of doing" and replay it on a different physical device.
+- **Hardware-bound identifiers** — anything tied to the specific physical machine (serial numbers, hardware-rooted keys, TPM state bound to this host's endorsement key) has to either be re-established on the new host or break the migration.
+- **Tight latency requirements** — workloads that can't tolerate even a brownout (let alone the blackout) aren't good fits; terminate-and-restart on a planned window may be cleaner.
 
-Some locally-attached resources *do* migrate — e.g., local SSDs can be moved along with the VM to the new host — but anything with hardware state that can't be captured in memory is usually in the "must terminate" bucket.
+Platforms handle these by either refusing live migration for the affected VM class, giving advance notice so the workload can drain/checkpoint, or offering a paravirtualized equivalent whose state *is* capturable.
 
 ## Testing live migration
 

--- a/docs/core/live-migration.md
+++ b/docs/core/live-migration.md
@@ -6,93 +6,40 @@ nav_order: 7
 
 # Live Migration
 
-Live migration moves a running VM from one host to another while the workload keeps executing. The VM's state — memory, CPU registers, device queues — is copied to the destination; the network is redirected; and the guest OS (and anything talking to it) is none the wiser. Its IPs, metadata, disks, and network settings are all preserved across the move.
+Migration — moving a running workload from one physical machine to another — is useful for several reasons. It enables **load balancing** for long-lived jobs, where you can shift work off an overloaded server (a natural question: why not short-lived jobs too? Probably because they'll finish before migration pays off). It gives you **controlled maintenance windows** instead of emergency ones, since you can move work off a machine before taking it down. It supports **fault tolerance** by letting you move jobs away from hardware that's getting flaky but hasn't failed yet. And it helps with **energy efficiency** — you can consolidate loads onto fewer machines to reduce cooling (A/C) needs. The data center is the natural environment for all of this, since you have many machines under unified control.
 
-The payoff is that cloud providers can patch or upgrade host infrastructure — kernel upgrades, firmware updates, rack repairs — without draining workloads or forcing customer-visible reboots.
+## Two basic strategies for moving state
 
-## Why migrate?
+When you migrate a workload, you have to deal with all the things it refers to — memory, files, network connections, devices. How you handle each piece of state falls into one of two approaches, and which one is available shapes what kinds of migration are even possible.
 
-- **Controlled maintenance windows** instead of emergency ones: move work off a machine before taking it down.
-- **Load balancing** for long-lived jobs: shift work off an overloaded server. (Short-lived jobs rarely justify the cost — they'll finish before migration pays off.)
-- **Fault tolerance**: move jobs away from hardware that's getting flaky but hasn't failed yet.
-- **Energy efficiency**: consolidate loads onto fewer machines to cut power and cooling.
-- **Operator-driven placement**: move a VM to a different host or host group — from a shared host to a dedicated one, to rebalance a noisy-neighbor situation, etc. — without restarting the workload.
+The first is **local names**: physically move the state to the new machine. This covers things like local memory contents, CPU registers, and local disk. It's the only option when the resource is tied to the original machine, but it doesn't work for some physical devices — a tape drive bolted to the source host can't come with you.
 
-The data center is the natural home for all of this: many machines under unified control, with the right kind of shared infrastructure to make the moves clean.
+The second is **global names**: the resource has a name that works from anywhere, so you just keep using it from the new location. Network-attached storage is the canonical example — the files live on a separate storage system, and both the old and new machine can reach them by the same name. For network identity, techniques like Network Address Translation (NAT) or layer 2 (Ethernet-level) addressing let an IP address effectively follow the workload to its new host.
 
-## What makes clean migration possible
+This distinction matters because of **residual dependencies** — leftover bits of state on the old machine that force it to stay up after migration (e.g., the old host still serving a local disk or forwarding network traffic for the migrated workload). Every piece of state handled by local names has to either move physically or become a residual dependency. Global names eliminate the choice: the state is already reachable from anywhere, so nothing has to move and nothing has to stay behind. Data centers are designed around global names (networked storage, managed IP addressing), which is what makes clean migration possible there — and it's why the VMM approach below works well in data centers specifically.
 
-A running workload refers to a bunch of things — memory, files, network connections, devices. Each piece of that state is handled in one of two ways:
+## VMM migration
 
-- **Local names** — state physically tied to the host. Memory, CPU registers, locally-attached disks, a USB device bolted to the box. To migrate, this state has to move with the VM.
-- **Global names** — state the workload reaches by a name that works from anywhere. A file on network-attached storage is reachable from any host; an IP address can follow the VM via layer-2 networking or NAT.
+VMM migration (Virtual Machine Monitor migration — moving an entire virtual machine) moves the whole OS as a single unit. You don't need to understand what's running inside or what state belongs to what; it's all just memory and devices from the VMM's perspective. This means you can migrate applications whose source code you don't have, and ones whose owners don't trust you enough to cooperate with a migration. Combined with the global names a data center provides, VMM migration can avoid residual dependencies entirely — the memory moves with the VM, and everything else (storage, network identity) is already reachable from the new host.
 
-The distinction matters because of **residual dependencies**: leftover bits of state on the old host that force it to stay up after migration (e.g., the old host still serving a local disk, or forwarding packets for the migrated VM). Every local-named resource has to either move physically or become a residual dependency. Global names eliminate that choice — the state is already reachable from anywhere.
+Non-live VMM migration (where the VM is suspended, moved, and resumed) is also useful outside the data center. You can migrate your work environment from office to home and back by putting the suspended VM on a USB key or sending it over the network — the "Collective" project called this "Internet suspend and resume."
 
-This is why data centers make clean migration practical. They're built around global names (networked storage, managed IP addressing). Combine that with a hypervisor that treats the guest OS as an opaque blob of memory and devices — no need to understand what's running inside, no need for guest cooperation — and you can move a VM with no lingering dependencies on the source.
+## Goals of live migration
 
-## Goals and trade-offs
+Live migration — moving the VM while it keeps running — has three goals in tension with each other: minimize downtime (the window where the service is unavailable), keep the total migration time manageable, and limit the impact on both the VM being moved and the local network during the move.
 
-Live migration optimizes several things at once, and they pull against each other:
+## How live migration works
 
-- **Downtime** — the window where the service is actually unavailable. Should be short enough to be invisible to the workload.
-- **Total migration time** — wall-clock from start to finish.
-- **Total transferred bytes** — how much data goes over the network between source and destination.
-- **Impact on other services** — the migration itself consumes bandwidth and CPU on both hosts. Too aggressive and it starves neighbors; too conservative and total migration time blows out. Throttling the migration (capping its network and CPU) is the standard lever.
-
-No scheme minimizes all four. A short downtime needs a fast final copy, which eats bandwidth. A small total-transferred-bytes number (no re-copying) tends to mean longer downtime. Every live migration algorithm is a particular choice among these trade-offs.
-
-## How it works
-
-The canonical algorithm is **pre-copy**: the VM keeps running on the source while its memory is streamed to the destination, with a brief pause at the end to catch up.
-
-1. **Allocate resources at the destination.** Confirm the target host can receive the VM (enough memory, CPU, etc.), spin up an empty receiving VM, and establish an authenticated channel between source and target.
-2. **Iteratively copy memory** (*source brownout*). While the VM keeps running, copy its memory pages to the destination. Since the VM is still writing, any page that gets modified after it's copied has to be re-copied. Iterate: copy everything, then the pages dirtied during that copy, then the ones dirtied during that pass, and so on. Stop when dirty memory drops below a threshold — or when you stop making forward progress, because the VM is dirtying pages as fast as you can send them.
-3. **Stop and copy the remainder** (*blackout*). Pause the VM on the source, send the last dirty pages, and wait for the destination to acknowledge. At that point the migration is committed — either side could restart the VM. This is the only window where the service is actually down; for most workloads it's invisible (one classic demo reported 60 ms for a running Quake 3 session — below the threshold a player notices). One subtle effect: wall-clock time keeps advancing while the VM is paused, so the guest clock appears to jump forward on resume. Long enough blackouts need a guest-side daemon to resync.
-4. **Redirect the network.** Send a gratuitous ARP — an unsolicited announcement to the local network saying "this IP now lives at this MAC address" — so traffic starts arriving at the new host. A few in-flight packets may be lost, but that happens on normal networks and TCP recovers.
-5. **Resume on the destination** (*target brownout*). The VM starts running again. The source may still provide temporary support — forwarding stray packets until the network fabric catches up with the new location, for example.
-6. **Tear down the source.** With no residual dependencies, the old host is completely free.
-
-The two **brownout** windows are periods of slightly degraded performance (disk, CPU, memory, and network utilization all dip as cycles and bandwidth go to the migration) while the VM is still running. The **blackout** is the actual pause. From the guest's perspective and from any external service talking to it, nothing changes — the VM's IPs, metadata, and configuration are all preserved.
-
-## Memory-copy strategies
-
-Pre-copy isn't the only way to move memory. The three main strategies differ in the order they transfer pages and when the VM switches hosts.
-
-- **Pre-copy** — the algorithm above. Easy to implement, no fast inter-host network required, and present in most mainstream hypervisors (Xen, KVM, VMware ESX). Convergence depends on the copy rate outpacing the VM's memory write rate; if the VM dirties pages faster than they can be sent, the iterations never shrink.
-- **Post-copy** — reverses the order. Suspend the source, copy a minimal slice of execution state (CPU registers, critical device state) to the destination, immediately transfer execution, then fetch pages on demand. Any access to an un-transferred page triggers a fault that's redirected back to the source over the network. Each page is sent at most once (total transferred bytes is minimized), but the destination is dependent on the source during the copy — page faults add latency, and a network hiccup can stall the VM.
-- **Hybrid-copy** — run some pre-copy iterations first, then switch to post-copy. The warm-up reduces the chance of page faults after execution transfers, trading off total migration time against worst-case latency.
+1. **Allocate resources at the destination.** Before starting, make sure the target host can actually receive the VM (enough memory, CPU, etc.).
+2. **Iteratively copy memory pages.** While the VM keeps running on the source, start copying its memory to the destination. The catch: the VM is still writing to memory, so any page that gets modified after you copy it has to be copied again ("dirtied" pages). You iterate — copy everything, then copy the pages that got dirtied during that copy, then the ones dirtied during that pass, and so on. You stop either when only a small amount of dirty memory remains or when you're not making forward progress (the VM is dirtying pages as fast as you can copy them). You can dedicate more bandwidth to later iterations to shrink the window in which new dirtying can happen.
+3. **Stop and copy the remainder.** Pause the VM on the source and copy the last bit of dirty state. This is the only window where the service is actually down. At the end of this step, the source and destination are identical — either could be restarted. Once the destination acknowledges the copy, the migration is committed (in the database transaction sense — it's officially done and can't be half-finished).
+4. **Redirect the network.** Send a "gratuitous ARP" packet — essentially an unsolicited announcement to the local network saying "this IP address now lives at this new MAC address" — so traffic starts arriving at the new host. A few packets in flight may be lost, but that kind of packet loss happens on normal networks anyway, and TCP will retransmit and recover.
+5. **Resume on the new host.** The VM starts running again on the destination.
+6. **Delete the source.** Tear down the original VM on the source host. No residual dependencies — the old host is completely free.
 
 ## Variants
 
-Live migration schemes also differ in how much the guest OS cooperates:
-
-- **Managed migration** — the VMM does everything from outside and the guest OS is oblivious.
-- **Managed with paravirtualization** — same, but the guest pitches in on specific optimizations: *stunning* (briefly freezing) processes that are dirtying memory too fast to keep up, or ballooning unused pages out so they don't have to be copied. ("Paravirtualization" = guest OS is modified to cooperate with the VMM, rather than being kept unaware.)
-- **Self migration** — the OS itself drives the migration. Harder: snapshotting a running OS using that same OS is like taking a photo of yourself taking the photo.
-
-## What's hard to migrate live
-
-The whole approach works because VM state — memory, registers, a few device queues — can be captured and reconstituted elsewhere. State that doesn't fit that model is where live migration breaks down:
-
-- **Passthrough devices** — when a VM has direct access to a physical device (GPU, FPGA, SR-IOV NIC), the device's internal state lives in hardware the hypervisor doesn't control. There's no clean way to snapshot "what the GPU was in the middle of" and replay it on a different physical chip.
-- **Hardware-bound identifiers** — anything tied to a specific physical machine (serial numbers, TPM state bound to the host's endorsement key, hardware-rooted secrets) has to be re-established on the destination or the migration can't preserve it.
-- **Tight latency budgets** — workloads that can't absorb even a brownout, let alone the blackout, aren't good candidates. Terminate-and-restart on a planned window may be the cleaner answer.
-
-Platforms handle these by refusing live migration for the affected VM class, giving advance notice so the workload can drain or checkpoint, or offering a paravirtualized equivalent whose state is capturable.
-
-## Operational concerns
-
-An individual migration is only half the story. At fleet scale there's a separate **scheduling layer** — cluster management software that decides when and which VMs migrate. It watches for trigger events (hardware-failure signals, planned maintenance, software/firmware rollouts, explicit operator requests), schedules migrations against policies (caps on concurrent migrations per customer, capacity limits on target hosts, fairness across tenants), and paces the fleet so a failing rack doesn't stampede the rest of the data center.
-
-Not every VM runs in "always migrate" mode. Platforms typically expose a per-VM **availability policy**:
-
-- **Maintenance behavior** — live-migrate (default) or terminate on an event. Termination suits workloads that need constant peak performance (no brownout acceptable) or apps that already handle instance failures.
-- **Restart behavior** — whether a terminated VM comes back automatically or waits for manual restart.
-
-The choice is whether the app prefers degraded-but-continuous (brownout) or clean-but-offline (terminate-and-restart).
-
-Live migration is complex enough to demand the same rigor as any other critical piece of infrastructure. **Fault injection** at each interesting point in the algorithm (network drops mid-copy, destination crash during blackout, source crash after commit) verifies the system either completes the migration or cleanly aborts. A **simulated maintenance event** API lets workload owners trigger a migration on demand against their own VMs, so they can confirm their availability policies behave the way they expect.
+There are a few flavors of live migration. **Managed migration** moves the OS without its cooperation — the VMM does everything from outside, and the guest OS doesn't even know it's happening. **Managed migration with paravirtualization** is the same thing but with the guest OS pitching in on specific optimizations: for instance, *stunning* (briefly freezing) rogue processes that are dirtying memory too fast to keep up with, or pushing unused memory pages out of the VM so they don't need to be copied at all. ("Paravirtualization" means the guest OS is modified to cooperate with the VMM, rather than being unaware of it.) **Self migration** goes further: the OS itself drives the migration. This is harder because you're trying to snapshot a running OS using that same OS — it's like trying to take a photo of yourself taking the photo.
 
 ## Hyper-V
 

--- a/docs/core/live-migration.md
+++ b/docs/core/live-migration.md
@@ -66,13 +66,28 @@ Any live migration will put pressure on shared resources. In live unified migrat
 ## How live migration works
 
 1. **Allocate resources at the destination.** Before starting, make sure the target host can actually receive the VM (enough memory, CPU, etc.).
-2. **Iteratively copy memory pages.** While the VM keeps running on the source, start copying its memory to the destination. The catch: the VM is still writing to memory, so any page that gets modified after you copy it has to be copied again ("dirtied" pages). You iterate — copy everything, then copy the pages that got dirtied during that copy, then the ones dirtied during that pass, and so on. You stop either when only a small amount of dirty memory remains or when you're not making forward progress (the VM is dirtying pages as fast as you can copy them). You can dedicate more bandwidth to later iterations to shrink the window in which new dirtying can happen.
-3. **Stop and copy the remainder.** Pause the VM on the source and copy the last bit of dirty state. This is the only window where the service is actually down. At the end of this step, the source and destination are identical — either could be restarted. Once the destination acknowledges the copy, the migration is committed (in the database transaction sense — it's officially done and can't be half-finished).
+2. **Iteratively copy memory pages** (*pre-migration brownout*). While the VM keeps running on the source, start copying its memory to the destination. The catch: the VM is still writing to memory, so any page that gets modified after you copy it has to be copied again ("dirtied" pages). You iterate — copy everything, then copy the pages that got dirtied during that copy, then the ones dirtied during that pass, and so on. You stop either when only a small amount of dirty memory remains or when you're not making forward progress (the VM is dirtying pages as fast as you can copy them). You can dedicate more bandwidth to later iterations to shrink the window in which new dirtying can happen. The decision to exit this phase is driven by an algorithm that balances remaining dirty bytes against the VM's current rate of change.
+3. **Stop and copy the remainder** (*blackout*). Pause the VM on the source and copy the last bit of dirty state. This is the only window where the service is actually down. At the end of this step, the source and destination are identical — either could be restarted. Once the destination acknowledges the copy, the migration is committed (in the database transaction sense — it's officially done and can't be half-finished).
 4. **Redirect the network.** Send a "gratuitous ARP" packet — essentially an unsolicited announcement to the local network saying "this IP address now lives at this new MAC address" — so traffic starts arriving at the new host. A few packets in flight may be lost, but that kind of packet loss happens on normal networks anyway, and TCP will retransmit and recover.
-5. **Resume on the new host.** The VM starts running again on the destination.
+5. **Resume on the new host** (*post-migration brownout*). The VM starts running again on the destination. The source VM may still be hanging around providing supporting functionality — for example, forwarding packets to and from the target until the network fabric catches up with the VM's new location.
 6. **Delete the source.** Tear down the original VM on the source host. No residual dependencies — the old host is completely free.
 
-The pause in step 3 creates a brief blackout, but for most workloads it's invisible. The payoff: when a major vulnerability needs patching, hosts can be updated without customer-visible reboots — versus the alternative of forcing customers to schedule downtime.
+The three windows are often called **pre-migration brownout**, **blackout**, and **post-migration brownout**. The brownouts are periods of slightly degraded performance with the VM still running; the blackout is the brief pause where the service is actually down. For most workloads the blackout is invisible. The payoff: when a major vulnerability needs patching, hosts can be updated without customer-visible reboots — versus the alternative of forcing customers to schedule downtime.
+
+### VM attributes are preserved
+
+Migration doesn't change the VM's identity or configuration. Metadata, internal and external IP addresses, network settings, attached disks — all unchanged. From the guest's perspective (and from any external service talking to it) nothing happened.
+
+### The scheduling layer
+
+An individual migration is only half the story. Something upstream has to decide **when** a VM migrates and **which** VMs migrate **when**. That's a separate cluster-management layer that:
+
+- Watches for trigger events — hardware-failure signals, planned maintenance windows, software-update rollouts.
+- Schedules migrations against policies — caps on how many VMs for a single customer can migrate at once, capacity-utilization limits on target hosts, fairness across tenants, etc.
+- Notifies the VM (or its operator) that a migration is about to happen, with a waiting period before the actual move.
+- Picks a target host, spins up an empty receiving VM there, and establishes an authenticated channel between source and target before any state is copied.
+
+This is where fleet-wide concerns live: you don't want every VM on a failing rack to migrate simultaneously and stampede the rest of the data center.
 
 ## Memory migration strategies
 
@@ -102,6 +117,31 @@ Hybrid-copy combines the two, trading off between minimizing downtime and minimi
 - **Managed migration** moves the OS without its cooperation — the VMM does everything from outside, and the guest OS doesn't even know it's happening.
 - **Managed migration with paravirtualization** is the same thing but with the guest OS pitching in on specific optimizations: for instance, *stunning* (briefly freezing) rogue processes that are dirtying memory too fast to keep up with, or pushing unused memory pages out of the VM so they don't need to be copied at all. ("Paravirtualization" means the guest OS is modified to cooperate with the VMM, rather than being unaware of it.)
 - **Self migration** goes further: the OS itself drives the migration. This is harder because you're trying to snapshot a running OS using that same OS — it's like trying to take a photo of yourself taking the photo.
+
+## Availability policies
+
+Live migration isn't the only option for handling a maintenance event. A cloud platform typically lets the VM owner pick a per-VM **maintenance behavior**:
+
+- **Live-migrate** — the default for most workloads. The VM keeps running through the event.
+- **Terminate** — stop the VM when a maintenance event fires. Suitable for workloads that need constant, maximum performance (no brownout acceptable), or for applications that are already architected to handle instance failures.
+
+A separate **restart behavior** controls whether a terminated VM automatically comes back up, or stays down until an operator restarts it. During a brownout, workloads may see a short dip in performance — terminate-and-restart avoids the dip at the cost of a hard interruption, so the choice depends on whether the app prefers degraded-but-continuous or clean-but-offline.
+
+## What can't live-migrate
+
+Not every workload can move while running. Two common cases:
+
+- **GPU-attached VMs** — the GPU state is hard to snapshot and transfer live, so these VMs are typically set to terminate. The platform instead gives advance notice (on the order of tens of minutes) before the maintenance event so the workload can checkpoint or drain gracefully.
+- **Preemptible / spot instances** — these trade availability for price and are always set to terminate on any disruption. Live migration is simply not offered.
+
+Some locally-attached resources *do* migrate — e.g., local SSDs can be moved along with the VM to the new host — but anything with hardware state that can't be captured in memory is usually in the "must terminate" bucket.
+
+## Testing live migration
+
+Live migration is a critical piece of production infrastructure, and it's too complex to trust without continuous testing. Two practices are worth calling out:
+
+- **Fault injection** — deliberately trigger failures at each interesting point in the migration algorithm (network drops mid-copy, destination crash during blackout, source crash after commit, etc.) and verify the system either completes the migration or cleanly aborts. Both active failures (something goes wrong) and passive ones (something just doesn't respond) should be covered.
+- **Simulated maintenance events** — expose a knob that lets operators trigger a migration on-demand against their own VMs. This lets them validate their availability policies: does the app actually survive a live-migrate brownout? Do preemptible workloads shut down cleanly? Does the terminate-and-restart path come back to a healthy state?
 
 ## Results
 

--- a/docs/core/live-migration.md
+++ b/docs/core/live-migration.md
@@ -16,6 +16,7 @@ Migration — moving a running workload from one physical machine to another —
 - **Controlled maintenance windows** instead of emergency ones: move work off a machine before taking it down.
 - **Fault tolerance**: move jobs away from hardware that's getting flaky but hasn't failed yet.
 - **Energy efficiency**: consolidate loads onto fewer machines to reduce cooling (A/C) needs.
+- **Operator-initiated placement**: deliberately move a VM to a different host or host group — e.g., from a shared host to a dedicated one, or to rebalance a noisy neighbor situation — without restarting the workload.
 
 The data center is the natural environment for all of this, since you have many machines under unified control.
 
@@ -67,12 +68,12 @@ Any live migration will put pressure on shared resources. In live unified migrat
 
 1. **Allocate resources at the destination.** Before starting, make sure the target host can actually receive the VM (enough memory, CPU, etc.).
 2. **Iteratively copy memory pages** (*pre-migration brownout*). While the VM keeps running on the source, start copying its memory to the destination. The catch: the VM is still writing to memory, so any page that gets modified after you copy it has to be copied again ("dirtied" pages). You iterate — copy everything, then copy the pages that got dirtied during that copy, then the ones dirtied during that pass, and so on. You stop either when only a small amount of dirty memory remains or when you're not making forward progress (the VM is dirtying pages as fast as you can copy them). You can dedicate more bandwidth to later iterations to shrink the window in which new dirtying can happen. The decision to exit this phase is driven by an algorithm that balances remaining dirty bytes against the VM's current rate of change.
-3. **Stop and copy the remainder** (*blackout*). Pause the VM on the source and copy the last bit of dirty state. This is the only window where the service is actually down. At the end of this step, the source and destination are identical — either could be restarted. Once the destination acknowledges the copy, the migration is committed (in the database transaction sense — it's officially done and can't be half-finished).
+3. **Stop and copy the remainder** (*blackout*). Pause the VM on the source and copy the last bit of dirty state. This is the only window where the service is actually down. At the end of this step, the source and destination are identical — either could be restarted. Once the destination acknowledges the copy, the migration is committed (in the database transaction sense — it's officially done and can't be half-finished). One subtle effect: wall-clock time keeps advancing while the VM is paused, so when the VM resumes its system clock appears to jump forward by the blackout duration. Short jumps are tolerable, but longer ones need a guest-side daemon to detect the skew and resync the clock.
 4. **Redirect the network.** Send a "gratuitous ARP" packet — essentially an unsolicited announcement to the local network saying "this IP address now lives at this new MAC address" — so traffic starts arriving at the new host. A few packets in flight may be lost, but that kind of packet loss happens on normal networks anyway, and TCP will retransmit and recover.
 5. **Resume on the new host** (*post-migration brownout*). The VM starts running again on the destination. The source VM may still be hanging around providing supporting functionality — for example, forwarding packets to and from the target until the network fabric catches up with the VM's new location.
 6. **Delete the source.** Tear down the original VM on the source host. No residual dependencies — the old host is completely free.
 
-The three windows are often called **pre-migration brownout**, **blackout**, and **post-migration brownout**. The brownouts are periods of slightly degraded performance with the VM still running; the blackout is the brief pause where the service is actually down. For most workloads the blackout is invisible. The payoff: when a major vulnerability needs patching, hosts can be updated without customer-visible reboots — versus the alternative of forcing customers to schedule downtime.
+The three windows are often called **pre-migration brownout** (sometimes *source brownout*), **blackout**, and **post-migration brownout** (sometimes *target brownout*). The brownouts are periods of slightly degraded performance with the VM still running — disk, CPU, memory, and network utilization can all dip temporarily as bandwidth and cycles are spent on the migration. The blackout is the brief pause where the service is actually down. For most workloads the blackout is invisible. The payoff: when a major vulnerability needs patching, hosts can be updated without customer-visible reboots — versus the alternative of forcing customers to schedule downtime.
 
 ### VM attributes are preserved
 
@@ -82,7 +83,7 @@ Migration doesn't change the VM's identity or configuration. Metadata, internal 
 
 An individual migration is only half the story. Something upstream has to decide **when** a VM migrates and **which** VMs migrate **when**. That's a separate cluster-management layer that:
 
-- Watches for trigger events — hardware-failure signals, planned maintenance windows, software-update rollouts.
+- Watches for trigger events — hardware-failure signals, planned maintenance windows, software-update rollouts, firmware/BIOS updates becoming available, or an operator explicitly requesting a migration for placement reasons.
 - Schedules migrations against policies — caps on how many VMs for a single customer can migrate at once, capacity-utilization limits on target hosts, fairness across tenants, etc.
 - Notifies the VM (or its operator) that a migration is about to happen, with a waiting period before the actual move.
 - Picks a target host, spins up an empty receiving VM there, and establishes an authenticated channel between source and target before any state is copied.

--- a/docs/core/live-migration.md
+++ b/docs/core/live-migration.md
@@ -35,13 +35,33 @@ VMM migration (Virtual Machine Monitor migration — moving an entire virtual ma
 
 Non-live VMM migration (where the VM is suspended, moved, and resumed) is also useful outside the data center. You can migrate your work environment from office to home and back by putting the suspended VM on a USB key or sending it over the network — the "Collective" project called this "Internet suspend and resume."
 
+## Classifications
+
+Live migration schemes can be classified along two axes.
+
+**By what has to move (storage topology):**
+- **Live memory migration** — the source and destination share storage, so only the VM's memory and device state need to move.
+- **Live storage migration** — the VM's disk image also has to be transferred.
+- **Live unified migration** — both memory and storage move together (required when there's no shared storage between the hosts).
+
+**By network scope:**
+- **Over LAN** — source and destination are in the same data center, with high bandwidth and low latency between them.
+- **Over WAN** — migration across a wide-area link. Much more challenging because of limited bandwidth and high latency; the same algorithms that work cleanly on a LAN can stall or take much longer.
+
 ## Goals of live migration
 
-Live migration — moving the VM while it keeps running — has three goals in tension with each other:
+Live migration — moving the VM while it keeps running — has several goals in tension with each other:
 
 - **Minimize downtime** (the window where the service is unavailable).
 - **Keep total migration time manageable.**
+- **Minimize total transferred bytes** — the total amount of data pushed over the network from source to destination.
 - **Limit the impact** on both the VM being moved and the local network during the move.
+
+A good live migration scheme seeks a reasonable trade-off among these — they can't all be minimized at once.
+
+### Impact on other services
+
+Any live migration will put pressure on shared resources. In live unified migration over LAN, for example, memory and storage are both transferred in a succession of iterations, and that traffic can easily consume the bandwidth between source and destination — starving other active services. Some service degradation is unavoidable, but it can be alleviated by throttling the migration: cap the network bandwidth and CPU resources the migration process is allowed to consume.
 
 ## How live migration works
 
@@ -53,6 +73,29 @@ Live migration — moving the VM while it keeps running — has three goals in t
 6. **Delete the source.** Tear down the original VM on the source host. No residual dependencies — the old host is completely free.
 
 The pause in step 3 creates a brief blackout, but for most workloads it's invisible. The payoff: when a major vulnerability needs patching, hosts can be updated without customer-visible reboots — versus the alternative of forcing customers to schedule downtime.
+
+## Memory migration strategies
+
+The "iteratively copy memory pages" step above describes one specific approach — **pre-copy**. There are three main strategies for moving memory state, differing in the order they transfer pages and when the VM switches hosts.
+
+### Pre-copy
+
+Pre-copy is easy to design and doesn't require a fast network between hosts, so it's implemented in most mainstream hypervisors (Xen, KVM, VMware ESX). It has two phases:
+
+1. **Warm-up phase**: Copy the whole memory from source to destination while the VM keeps running on the source. Any pages dirtied during that copy are re-copied in a second iteration, and so on. This repeats until the remaining dirty memory drops below a pre-defined threshold. Convergence depends on the copy rate staying faster than the VM's memory write rate — if the VM dirties pages faster than you can send them, the iterations never shrink.
+2. **Stop-and-copy phase**: Suspend the VM on the source, copy the last bit of dirty memory, then resume the VM on the destination.
+
+### Post-copy
+
+Post-copy reverses the order. It starts by suspending the source VM, copying a minimal subset of execution state (CPU registers, etc.) to the destination, and immediately transferring execution control — the VM resumes on the destination almost right away.
+
+Any access to un-transferred memory triggers a page fault, which is trapped at the destination and redirected back to the source over the network to fetch that page. In parallel, a background thread copies over the remaining memory while the VM runs on the destination.
+
+This minimizes total transferred bytes (each page is sent at most once) but makes the destination VM dependent on the source during the copy — page faults add latency, and if the network between them hiccups, the VM is stuck.
+
+### Hybrid-copy
+
+Hybrid-copy combines the two, trading off between minimizing downtime and minimizing total migration time. It runs some pre-copy warm-up iterations first, then switches to post-copy. The initial warm-up reduces the chance of page faults on the destination, because a large portion of memory is already there by the time execution transfers.
 
 ## Variants
 

--- a/docs/core/live-migration.md
+++ b/docs/core/live-migration.md
@@ -8,15 +8,61 @@ nav_order: 7
 
 Live migration lets a cloud provider patch or upgrade host infrastructure (e.g., host kernel upgrades) without disrupting the VMs running on it. Instead of draining and rebooting a host, VMs are relocated to other hosts while still running.
 
-## How it works
+## Why migrate?
 
-1. A VM is running on a host that needs to go offline.
-2. A target VM is created on a different host; state begins copying over (RAM, VM spec, machine type, attached disks, network connections).
-3. Once most state is copied, the source VM is briefly paused.
-4. The remaining state copies over.
-5. The VM is unpaused on the target host.
+Migration — moving a running workload from one physical machine to another — is useful for several reasons:
 
-The pause creates a brief blackout, but for most workloads it's invisible. The payoff: when a major vulnerability needs patching, hosts can be updated without customer-visible reboots — versus the alternative of forcing customers to schedule downtime.
+- **Load balancing** for long-lived jobs: shift work off an overloaded server. (A natural question: why not short-lived jobs too? Probably because they'll finish before migration pays off.)
+- **Controlled maintenance windows** instead of emergency ones: move work off a machine before taking it down.
+- **Fault tolerance**: move jobs away from hardware that's getting flaky but hasn't failed yet.
+- **Energy efficiency**: consolidate loads onto fewer machines to reduce cooling (A/C) needs.
+
+The data center is the natural environment for all of this, since you have many machines under unified control.
+
+## Two basic strategies for moving state
+
+When you migrate a workload, you have to deal with all the things it refers to — memory, files, network connections, devices. How you handle each piece of state falls into one of two approaches, and which one is available shapes what kinds of migration are even possible.
+
+**Local names**: physically move the state to the new machine. This covers things like local memory contents, CPU registers, and local disk. It's the only option when the resource is tied to the original machine, but it doesn't work for some physical devices — a tape drive bolted to the source host can't come with you.
+
+**Global names**: the resource has a name that works from anywhere, so you just keep using it from the new location. Network-attached storage is the canonical example — the files live on a separate storage system, and both the old and new machine can reach them by the same name. For network identity, techniques like Network Address Translation (NAT) or layer 2 (Ethernet-level) addressing let an IP address effectively follow the workload to its new host.
+
+This distinction matters because of **residual dependencies** — leftover bits of state on the old machine that force it to stay up after migration (e.g., the old host still serving a local disk or forwarding network traffic for the migrated workload). Every piece of state handled by local names has to either move physically or become a residual dependency. Global names eliminate the choice: the state is already reachable from anywhere, so nothing has to move and nothing has to stay behind. Data centers are designed around global names (networked storage, managed IP addressing), which is what makes clean migration possible there — and it's why the VMM approach below works well in data centers specifically.
+
+## VMM migration
+
+VMM migration (Virtual Machine Monitor migration — moving an entire virtual machine) moves the whole OS as a single unit. You don't need to understand what's running inside or what state belongs to what; it's all just memory and devices from the VMM's perspective. This means you can migrate applications whose source code you don't have, and ones whose owners don't trust you enough to cooperate with a migration. Combined with the global names a data center provides, VMM migration can avoid residual dependencies entirely — the memory moves with the VM, and everything else (storage, network identity) is already reachable from the new host.
+
+Non-live VMM migration (where the VM is suspended, moved, and resumed) is also useful outside the data center. You can migrate your work environment from office to home and back by putting the suspended VM on a USB key or sending it over the network — the "Collective" project called this "Internet suspend and resume."
+
+## Goals of live migration
+
+Live migration — moving the VM while it keeps running — has three goals in tension with each other:
+
+- **Minimize downtime** (the window where the service is unavailable).
+- **Keep total migration time manageable.**
+- **Limit the impact** on both the VM being moved and the local network during the move.
+
+## How live migration works
+
+1. **Allocate resources at the destination.** Before starting, make sure the target host can actually receive the VM (enough memory, CPU, etc.).
+2. **Iteratively copy memory pages.** While the VM keeps running on the source, start copying its memory to the destination. The catch: the VM is still writing to memory, so any page that gets modified after you copy it has to be copied again ("dirtied" pages). You iterate — copy everything, then copy the pages that got dirtied during that copy, then the ones dirtied during that pass, and so on. You stop either when only a small amount of dirty memory remains or when you're not making forward progress (the VM is dirtying pages as fast as you can copy them). You can dedicate more bandwidth to later iterations to shrink the window in which new dirtying can happen.
+3. **Stop and copy the remainder.** Pause the VM on the source and copy the last bit of dirty state. This is the only window where the service is actually down. At the end of this step, the source and destination are identical — either could be restarted. Once the destination acknowledges the copy, the migration is committed (in the database transaction sense — it's officially done and can't be half-finished).
+4. **Redirect the network.** Send a "gratuitous ARP" packet — essentially an unsolicited announcement to the local network saying "this IP address now lives at this new MAC address" — so traffic starts arriving at the new host. A few packets in flight may be lost, but that kind of packet loss happens on normal networks anyway, and TCP will retransmit and recover.
+5. **Resume on the new host.** The VM starts running again on the destination.
+6. **Delete the source.** Tear down the original VM on the source host. No residual dependencies — the old host is completely free.
+
+The pause in step 3 creates a brief blackout, but for most workloads it's invisible. The payoff: when a major vulnerability needs patching, hosts can be updated without customer-visible reboots — versus the alternative of forcing customers to schedule downtime.
+
+## Variants
+
+- **Managed migration** moves the OS without its cooperation — the VMM does everything from outside, and the guest OS doesn't even know it's happening.
+- **Managed migration with paravirtualization** is the same thing but with the guest OS pitching in on specific optimizations: for instance, *stunning* (briefly freezing) rogue processes that are dirtying memory too fast to keep up with, or pushing unused memory pages out of the VM so they don't need to be copied at all. ("Paravirtualization" means the guest OS is modified to cooperate with the VMM, rather than being unaware of it.)
+- **Self migration** goes further: the OS itself drives the migration. This is harder because you're trying to snapshot a running OS using that same OS — it's like trying to take a photo of yourself taking the photo.
+
+## Results
+
+The approach delivers on all three goals. Downtimes are very short — 60ms for a running Quake 3 game, which is below the threshold a player would notice. Impact on the running service and the local network stays limited and reasonable. Total migration time is on the order of minutes. And once migration finishes, the source host is completely free of the workload, with no lingering dependencies.
 
 ## Hyper-V
 

--- a/docs/core/live-migration.md
+++ b/docs/core/live-migration.md
@@ -6,148 +6,93 @@ nav_order: 7
 
 # Live Migration
 
-Live migration lets a cloud provider patch or upgrade host infrastructure (e.g., host kernel upgrades) without disrupting the VMs running on it. Instead of draining and rebooting a host, VMs are relocated to other hosts while still running.
+Live migration moves a running VM from one host to another while the workload keeps executing. The VM's state — memory, CPU registers, device queues — is copied to the destination; the network is redirected; and the guest OS (and anything talking to it) is none the wiser. Its IPs, metadata, disks, and network settings are all preserved across the move.
+
+The payoff is that cloud providers can patch or upgrade host infrastructure — kernel upgrades, firmware updates, rack repairs — without draining workloads or forcing customer-visible reboots.
 
 ## Why migrate?
 
-Migration — moving a running workload from one physical machine to another — is useful for several reasons:
-
-- **Load balancing** for long-lived jobs: shift work off an overloaded server. (A natural question: why not short-lived jobs too? Probably because they'll finish before migration pays off.)
 - **Controlled maintenance windows** instead of emergency ones: move work off a machine before taking it down.
+- **Load balancing** for long-lived jobs: shift work off an overloaded server. (Short-lived jobs rarely justify the cost — they'll finish before migration pays off.)
 - **Fault tolerance**: move jobs away from hardware that's getting flaky but hasn't failed yet.
-- **Energy efficiency**: consolidate loads onto fewer machines to reduce cooling (A/C) needs.
-- **Operator-initiated placement**: deliberately move a VM to a different host or host group — e.g., from a shared host to a dedicated one, or to rebalance a noisy neighbor situation — without restarting the workload.
+- **Energy efficiency**: consolidate loads onto fewer machines to cut power and cooling.
+- **Operator-driven placement**: move a VM to a different host or host group — from a shared host to a dedicated one, to rebalance a noisy-neighbor situation, etc. — without restarting the workload.
 
-The data center is the natural environment for all of this, since you have many machines under unified control.
+The data center is the natural home for all of this: many machines under unified control, with the right kind of shared infrastructure to make the moves clean.
 
-## Two basic strategies for moving state
+## What makes clean migration possible
 
-When you migrate a workload, you have to deal with all the things it refers to — memory, files, network connections, devices. How you handle each piece of state falls into one of two approaches, and which one is available shapes what kinds of migration are even possible.
+A running workload refers to a bunch of things — memory, files, network connections, devices. Each piece of that state is handled in one of two ways:
 
-**Local names**: physically move the state to the new machine. This covers things like local memory contents, CPU registers, and local disk. It's the only option when the resource is tied to the original machine, but it doesn't work for some physical devices — a tape drive bolted to the source host can't come with you.
+- **Local names** — state physically tied to the host. Memory, CPU registers, locally-attached disks, a USB device bolted to the box. To migrate, this state has to move with the VM.
+- **Global names** — state the workload reaches by a name that works from anywhere. A file on network-attached storage is reachable from any host; an IP address can follow the VM via layer-2 networking or NAT.
 
-**Global names**: the resource has a name that works from anywhere, so you just keep using it from the new location. Network-attached storage is the canonical example — the files live on a separate storage system, and both the old and new machine can reach them by the same name. For network identity, techniques like Network Address Translation (NAT) or layer 2 (Ethernet-level) addressing let an IP address effectively follow the workload to its new host.
+The distinction matters because of **residual dependencies**: leftover bits of state on the old host that force it to stay up after migration (e.g., the old host still serving a local disk, or forwarding packets for the migrated VM). Every local-named resource has to either move physically or become a residual dependency. Global names eliminate that choice — the state is already reachable from anywhere.
 
-This distinction matters because of **residual dependencies** — leftover bits of state on the old machine that force it to stay up after migration (e.g., the old host still serving a local disk or forwarding network traffic for the migrated workload). Every piece of state handled by local names has to either move physically or become a residual dependency. Global names eliminate the choice: the state is already reachable from anywhere, so nothing has to move and nothing has to stay behind. Data centers are designed around global names (networked storage, managed IP addressing), which is what makes clean migration possible there — and it's why the VMM approach below works well in data centers specifically.
+This is why data centers make clean migration practical. They're built around global names (networked storage, managed IP addressing). Combine that with a hypervisor that treats the guest OS as an opaque blob of memory and devices — no need to understand what's running inside, no need for guest cooperation — and you can move a VM with no lingering dependencies on the source.
 
-## VMM migration
+## Goals and trade-offs
 
-VMM migration (Virtual Machine Monitor migration — moving an entire virtual machine) moves the whole OS as a single unit. You don't need to understand what's running inside or what state belongs to what; it's all just memory and devices from the VMM's perspective. This means you can migrate applications whose source code you don't have, and ones whose owners don't trust you enough to cooperate with a migration. Combined with the global names a data center provides, VMM migration can avoid residual dependencies entirely — the memory moves with the VM, and everything else (storage, network identity) is already reachable from the new host.
+Live migration optimizes several things at once, and they pull against each other:
 
-Non-live VMM migration (where the VM is suspended, moved, and resumed) is also useful outside the data center. You can migrate your work environment from office to home and back by putting the suspended VM on a USB key or sending it over the network — the "Collective" project called this "Internet suspend and resume."
+- **Downtime** — the window where the service is actually unavailable. Should be short enough to be invisible to the workload.
+- **Total migration time** — wall-clock from start to finish.
+- **Total transferred bytes** — how much data goes over the network between source and destination.
+- **Impact on other services** — the migration itself consumes bandwidth and CPU on both hosts. Too aggressive and it starves neighbors; too conservative and total migration time blows out. Throttling the migration (capping its network and CPU) is the standard lever.
 
-## Classifications
+No scheme minimizes all four. A short downtime needs a fast final copy, which eats bandwidth. A small total-transferred-bytes number (no re-copying) tends to mean longer downtime. Every live migration algorithm is a particular choice among these trade-offs.
 
-Live migration schemes can be classified along two axes.
+## How it works
 
-**By what has to move (storage topology):**
-- **Live memory migration** — the source and destination share storage, so only the VM's memory and device state need to move.
-- **Live storage migration** — the VM's disk image also has to be transferred.
-- **Live unified migration** — both memory and storage move together (required when there's no shared storage between the hosts).
+The canonical algorithm is **pre-copy**: the VM keeps running on the source while its memory is streamed to the destination, with a brief pause at the end to catch up.
 
-**By network scope:**
-- **Over LAN** — source and destination are in the same data center, with high bandwidth and low latency between them.
-- **Over WAN** — migration across a wide-area link. Much more challenging because of limited bandwidth and high latency; the same algorithms that work cleanly on a LAN can stall or take much longer.
+1. **Allocate resources at the destination.** Confirm the target host can receive the VM (enough memory, CPU, etc.), spin up an empty receiving VM, and establish an authenticated channel between source and target.
+2. **Iteratively copy memory** (*source brownout*). While the VM keeps running, copy its memory pages to the destination. Since the VM is still writing, any page that gets modified after it's copied has to be re-copied. Iterate: copy everything, then the pages dirtied during that copy, then the ones dirtied during that pass, and so on. Stop when dirty memory drops below a threshold — or when you stop making forward progress, because the VM is dirtying pages as fast as you can send them.
+3. **Stop and copy the remainder** (*blackout*). Pause the VM on the source, send the last dirty pages, and wait for the destination to acknowledge. At that point the migration is committed — either side could restart the VM. This is the only window where the service is actually down; for most workloads it's invisible (one classic demo reported 60 ms for a running Quake 3 session — below the threshold a player notices). One subtle effect: wall-clock time keeps advancing while the VM is paused, so the guest clock appears to jump forward on resume. Long enough blackouts need a guest-side daemon to resync.
+4. **Redirect the network.** Send a gratuitous ARP — an unsolicited announcement to the local network saying "this IP now lives at this MAC address" — so traffic starts arriving at the new host. A few in-flight packets may be lost, but that happens on normal networks and TCP recovers.
+5. **Resume on the destination** (*target brownout*). The VM starts running again. The source may still provide temporary support — forwarding stray packets until the network fabric catches up with the new location, for example.
+6. **Tear down the source.** With no residual dependencies, the old host is completely free.
 
-## Goals of live migration
+The two **brownout** windows are periods of slightly degraded performance (disk, CPU, memory, and network utilization all dip as cycles and bandwidth go to the migration) while the VM is still running. The **blackout** is the actual pause. From the guest's perspective and from any external service talking to it, nothing changes — the VM's IPs, metadata, and configuration are all preserved.
 
-Live migration — moving the VM while it keeps running — has several goals in tension with each other:
+## Memory-copy strategies
 
-- **Minimize downtime** (the window where the service is unavailable).
-- **Keep total migration time manageable.**
-- **Minimize total transferred bytes** — the total amount of data pushed over the network from source to destination.
-- **Limit the impact** on both the VM being moved and the local network during the move.
+Pre-copy isn't the only way to move memory. The three main strategies differ in the order they transfer pages and when the VM switches hosts.
 
-A good live migration scheme seeks a reasonable trade-off among these — they can't all be minimized at once.
-
-### Impact on other services
-
-Any live migration will put pressure on shared resources. In live unified migration over LAN, for example, memory and storage are both transferred in a succession of iterations, and that traffic can easily consume the bandwidth between source and destination — starving other active services. Some service degradation is unavoidable, but it can be alleviated by throttling the migration: cap the network bandwidth and CPU resources the migration process is allowed to consume.
-
-## How live migration works
-
-1. **Allocate resources at the destination.** Before starting, make sure the target host can actually receive the VM (enough memory, CPU, etc.).
-2. **Iteratively copy memory pages** (*pre-migration brownout*). While the VM keeps running on the source, start copying its memory to the destination. The catch: the VM is still writing to memory, so any page that gets modified after you copy it has to be copied again ("dirtied" pages). You iterate — copy everything, then copy the pages that got dirtied during that copy, then the ones dirtied during that pass, and so on. You stop either when only a small amount of dirty memory remains or when you're not making forward progress (the VM is dirtying pages as fast as you can copy them). You can dedicate more bandwidth to later iterations to shrink the window in which new dirtying can happen. The decision to exit this phase is driven by an algorithm that balances remaining dirty bytes against the VM's current rate of change.
-3. **Stop and copy the remainder** (*blackout*). Pause the VM on the source and copy the last bit of dirty state. This is the only window where the service is actually down. At the end of this step, the source and destination are identical — either could be restarted. Once the destination acknowledges the copy, the migration is committed (in the database transaction sense — it's officially done and can't be half-finished). One subtle effect: wall-clock time keeps advancing while the VM is paused, so when the VM resumes its system clock appears to jump forward by the blackout duration. Short jumps are tolerable, but longer ones need a guest-side daemon to detect the skew and resync the clock.
-4. **Redirect the network.** Send a "gratuitous ARP" packet — essentially an unsolicited announcement to the local network saying "this IP address now lives at this new MAC address" — so traffic starts arriving at the new host. A few packets in flight may be lost, but that kind of packet loss happens on normal networks anyway, and TCP will retransmit and recover.
-5. **Resume on the new host** (*post-migration brownout*). The VM starts running again on the destination. The source VM may still be hanging around providing supporting functionality — for example, forwarding packets to and from the target until the network fabric catches up with the VM's new location.
-6. **Delete the source.** Tear down the original VM on the source host. No residual dependencies — the old host is completely free.
-
-The three windows are often called **pre-migration brownout** (sometimes *source brownout*), **blackout**, and **post-migration brownout** (sometimes *target brownout*). The brownouts are periods of slightly degraded performance with the VM still running — disk, CPU, memory, and network utilization can all dip temporarily as bandwidth and cycles are spent on the migration. The blackout is the brief pause where the service is actually down. For most workloads the blackout is invisible. The payoff: when a major vulnerability needs patching, hosts can be updated without customer-visible reboots — versus the alternative of forcing customers to schedule downtime.
-
-### VM attributes are preserved
-
-Migration doesn't change the VM's identity or configuration. Metadata, internal and external IP addresses, network settings, attached disks — all unchanged. From the guest's perspective (and from any external service talking to it) nothing happened.
-
-### The scheduling layer
-
-An individual migration is only half the story. Something upstream has to decide **when** a VM migrates and **which** VMs migrate **when**. That's a separate cluster-management layer that:
-
-- Watches for trigger events — hardware-failure signals, planned maintenance windows, software-update rollouts, firmware/BIOS updates becoming available, or an operator explicitly requesting a migration for placement reasons.
-- Schedules migrations against policies — caps on how many VMs for a single customer can migrate at once, capacity-utilization limits on target hosts, fairness across tenants, etc.
-- Notifies the VM (or its operator) that a migration is about to happen, with a waiting period before the actual move.
-- Picks a target host, spins up an empty receiving VM there, and establishes an authenticated channel between source and target before any state is copied.
-
-This is where fleet-wide concerns live: you don't want every VM on a failing rack to migrate simultaneously and stampede the rest of the data center.
-
-## Memory migration strategies
-
-The "iteratively copy memory pages" step above describes one specific approach — **pre-copy**. There are three main strategies for moving memory state, differing in the order they transfer pages and when the VM switches hosts.
-
-### Pre-copy
-
-Pre-copy is easy to design and doesn't require a fast network between hosts, so it's implemented in most mainstream hypervisors (Xen, KVM, VMware ESX). It has two phases:
-
-1. **Warm-up phase**: Copy the whole memory from source to destination while the VM keeps running on the source. Any pages dirtied during that copy are re-copied in a second iteration, and so on. This repeats until the remaining dirty memory drops below a pre-defined threshold. Convergence depends on the copy rate staying faster than the VM's memory write rate — if the VM dirties pages faster than you can send them, the iterations never shrink.
-2. **Stop-and-copy phase**: Suspend the VM on the source, copy the last bit of dirty memory, then resume the VM on the destination.
-
-### Post-copy
-
-Post-copy reverses the order. It starts by suspending the source VM, copying a minimal subset of execution state (CPU registers, etc.) to the destination, and immediately transferring execution control — the VM resumes on the destination almost right away.
-
-Any access to un-transferred memory triggers a page fault, which is trapped at the destination and redirected back to the source over the network to fetch that page. In parallel, a background thread copies over the remaining memory while the VM runs on the destination.
-
-This minimizes total transferred bytes (each page is sent at most once) but makes the destination VM dependent on the source during the copy — page faults add latency, and if the network between them hiccups, the VM is stuck.
-
-### Hybrid-copy
-
-Hybrid-copy combines the two, trading off between minimizing downtime and minimizing total migration time. It runs some pre-copy warm-up iterations first, then switches to post-copy. The initial warm-up reduces the chance of page faults on the destination, because a large portion of memory is already there by the time execution transfers.
+- **Pre-copy** — the algorithm above. Easy to implement, no fast inter-host network required, and present in most mainstream hypervisors (Xen, KVM, VMware ESX). Convergence depends on the copy rate outpacing the VM's memory write rate; if the VM dirties pages faster than they can be sent, the iterations never shrink.
+- **Post-copy** — reverses the order. Suspend the source, copy a minimal slice of execution state (CPU registers, critical device state) to the destination, immediately transfer execution, then fetch pages on demand. Any access to an un-transferred page triggers a fault that's redirected back to the source over the network. Each page is sent at most once (total transferred bytes is minimized), but the destination is dependent on the source during the copy — page faults add latency, and a network hiccup can stall the VM.
+- **Hybrid-copy** — run some pre-copy iterations first, then switch to post-copy. The warm-up reduces the chance of page faults after execution transfers, trading off total migration time against worst-case latency.
 
 ## Variants
 
-- **Managed migration** moves the OS without its cooperation — the VMM does everything from outside, and the guest OS doesn't even know it's happening.
-- **Managed migration with paravirtualization** is the same thing but with the guest OS pitching in on specific optimizations: for instance, *stunning* (briefly freezing) rogue processes that are dirtying memory too fast to keep up with, or pushing unused memory pages out of the VM so they don't need to be copied at all. ("Paravirtualization" means the guest OS is modified to cooperate with the VMM, rather than being unaware of it.)
-- **Self migration** goes further: the OS itself drives the migration. This is harder because you're trying to snapshot a running OS using that same OS — it's like trying to take a photo of yourself taking the photo.
+Live migration schemes also differ in how much the guest OS cooperates:
 
-## Availability policies
-
-Live migration isn't the only option for handling a maintenance event. A cloud platform typically lets the VM owner pick a per-VM **maintenance behavior**:
-
-- **Live-migrate** — the default for most workloads. The VM keeps running through the event.
-- **Terminate** — stop the VM when a maintenance event fires. Suitable for workloads that need constant, maximum performance (no brownout acceptable), or for applications that are already architected to handle instance failures.
-
-A separate **restart behavior** controls whether a terminated VM automatically comes back up, or stays down until an operator restarts it. During a brownout, workloads may see a short dip in performance — terminate-and-restart avoids the dip at the cost of a hard interruption, so the choice depends on whether the app prefers degraded-but-continuous or clean-but-offline.
+- **Managed migration** — the VMM does everything from outside and the guest OS is oblivious.
+- **Managed with paravirtualization** — same, but the guest pitches in on specific optimizations: *stunning* (briefly freezing) processes that are dirtying memory too fast to keep up, or ballooning unused pages out so they don't have to be copied. ("Paravirtualization" = guest OS is modified to cooperate with the VMM, rather than being kept unaware.)
+- **Self migration** — the OS itself drives the migration. Harder: snapshotting a running OS using that same OS is like taking a photo of yourself taking the photo.
 
 ## What's hard to migrate live
 
-The algorithm above works because a VM's state — guest memory, CPU registers, a few device queues — can be captured, copied, and reconstituted on another host. State that doesn't fit that model is where live migration gets hard or impossible:
+The whole approach works because VM state — memory, registers, a few device queues — can be captured and reconstituted elsewhere. State that doesn't fit that model is where live migration breaks down:
 
-- **Passthrough devices** — when a VM is given direct access to a physical device (GPU, FPGA, SR-IOV NIC, etc.), the device's internal state lives in hardware, not in memory the hypervisor controls. There's no clean way to snapshot "what the GPU was in the middle of doing" and replay it on a different physical device.
-- **Hardware-bound identifiers** — anything tied to the specific physical machine (serial numbers, hardware-rooted keys, TPM state bound to this host's endorsement key) has to either be re-established on the new host or break the migration.
-- **Tight latency requirements** — workloads that can't tolerate even a brownout (let alone the blackout) aren't good fits; terminate-and-restart on a planned window may be cleaner.
+- **Passthrough devices** — when a VM has direct access to a physical device (GPU, FPGA, SR-IOV NIC), the device's internal state lives in hardware the hypervisor doesn't control. There's no clean way to snapshot "what the GPU was in the middle of" and replay it on a different physical chip.
+- **Hardware-bound identifiers** — anything tied to a specific physical machine (serial numbers, TPM state bound to the host's endorsement key, hardware-rooted secrets) has to be re-established on the destination or the migration can't preserve it.
+- **Tight latency budgets** — workloads that can't absorb even a brownout, let alone the blackout, aren't good candidates. Terminate-and-restart on a planned window may be the cleaner answer.
 
-Platforms handle these by either refusing live migration for the affected VM class, giving advance notice so the workload can drain/checkpoint, or offering a paravirtualized equivalent whose state *is* capturable.
+Platforms handle these by refusing live migration for the affected VM class, giving advance notice so the workload can drain or checkpoint, or offering a paravirtualized equivalent whose state is capturable.
 
-## Testing live migration
+## Operational concerns
 
-Live migration is a critical piece of production infrastructure, and it's too complex to trust without continuous testing. Two practices are worth calling out:
+An individual migration is only half the story. At fleet scale there's a separate **scheduling layer** — cluster management software that decides when and which VMs migrate. It watches for trigger events (hardware-failure signals, planned maintenance, software/firmware rollouts, explicit operator requests), schedules migrations against policies (caps on concurrent migrations per customer, capacity limits on target hosts, fairness across tenants), and paces the fleet so a failing rack doesn't stampede the rest of the data center.
 
-- **Fault injection** — deliberately trigger failures at each interesting point in the migration algorithm (network drops mid-copy, destination crash during blackout, source crash after commit, etc.) and verify the system either completes the migration or cleanly aborts. Both active failures (something goes wrong) and passive ones (something just doesn't respond) should be covered.
-- **Simulated maintenance events** — expose a knob that lets operators trigger a migration on-demand against their own VMs. This lets them validate their availability policies: does the app actually survive a live-migrate brownout? Do preemptible workloads shut down cleanly? Does the terminate-and-restart path come back to a healthy state?
+Not every VM runs in "always migrate" mode. Platforms typically expose a per-VM **availability policy**:
 
-## Results
+- **Maintenance behavior** — live-migrate (default) or terminate on an event. Termination suits workloads that need constant peak performance (no brownout acceptable) or apps that already handle instance failures.
+- **Restart behavior** — whether a terminated VM comes back automatically or waits for manual restart.
 
-The approach delivers on all three goals. Downtimes are very short — 60ms for a running Quake 3 game, which is below the threshold a player would notice. Impact on the running service and the local network stays limited and reasonable. Total migration time is on the order of minutes. And once migration finishes, the source host is completely free of the workload, with no lingering dependencies.
+The choice is whether the app prefers degraded-but-continuous (brownout) or clean-but-offline (terminate-and-restart).
+
+Live migration is complex enough to demand the same rigor as any other critical piece of infrastructure. **Fault injection** at each interesting point in the algorithm (network drops mid-copy, destination crash during blackout, source crash after commit) verifies the system either completes the migration or cleanly aborts. A **simulated maintenance event** API lets workload owners trigger a migration on demand against their own VMs, so they can confirm their availability policies behave the way they expect.
 
 ## Hyper-V
 

--- a/docs/core/live-migration.md
+++ b/docs/core/live-migration.md
@@ -1,0 +1,27 @@
+---
+title: Live Migration
+parent: Core Concepts
+nav_order: 7
+---
+
+# Live Migration
+
+Live migration lets a cloud provider patch or upgrade host infrastructure (e.g., host kernel upgrades) without disrupting the VMs running on it. Instead of draining and rebooting a host, VMs are relocated to other hosts while still running.
+
+## How it works
+
+1. A VM is running on a host that needs to go offline.
+2. A target VM is created on a different host; state begins copying over (RAM, VM spec, machine type, attached disks, network connections).
+3. Once most state is copied, the source VM is briefly paused.
+4. The remaining state copies over.
+5. The VM is unpaused on the target host.
+
+The pause creates a brief blackout, but for most workloads it's invisible. The payoff: when a major vulnerability needs patching, hosts can be updated without customer-visible reboots — versus the alternative of forcing customers to schedule downtime.
+
+## Hyper-V
+
+_Notes to come._
+
+## TDX Live Migration
+
+_Notes to come._


### PR DESCRIPTION
## Changes

### Theme Migration
- Migrated site theme from Cayman to just-the-docs
- Updated `_config.yml` with just-the-docs configuration
- Removed custom CSS and JavaScript files (dark-mode.js, search.js, custom styles)
- Removed search functionality files (search.json, search.md)

### Documentation Restructuring
- Added index pages for better navigation:
  - `docs/core/index.md`
  - `docs/containers/index.md`
  - `docs/tools/index.md`
  - `docs/misc/index.md`
- Added new "Live Migration" page under Core Concepts
- Reorganized and updated content in multiple documentation files for clarity and coherence

### Asset Updates
- Renamed image files for consistency and clarity (e.g., `image-1.png` → `docker-architecture-overview.png`)
- Cleaned up unused layout and styling files

### Content Refinements
- Simplified and restructured Live Migration documentation
- Updated various core, container, and tools documentation files
- Condensed scratch.md significantly
- Updated index.md and 404.md