### PR TITLE
Add TEE security principles and practice pages

### DIFF
--- a/docs/core/tee-security-principles.md
+++ b/docs/core/tee-security-principles.md
@@ -1,0 +1,53 @@
+---
+title: TEE Security Principles
+parent: Core Concepts
+nav_order: 8
+---
+
+# TEE Security Principles
+
+A TEE is only as trustworthy as its attestation boundary is complete. If critical inputs fall outside the measurement, the entire trust model breaks — regardless of how strong the hardware isolation is.
+
+## Core Principles
+
+### Measure every input, not just code
+Environment variables, configs, feature flags, and runtime parameters loaded after attestation create a gap between what the client verified and what actually executes. Anything consumed at runtime must be measured or treated as hostile.
+
+### The attack surface includes everything your code trusts
+Hardware configuration (like ACPI tables) sits below application code but still shapes behavior. A malicious hypervisor can exploit unmeasured hardware definitions to access protected memory while attestation appears valid. Most teams measure their binaries but forget the layers beneath them.
+
+### Never trust self-reported trustworthiness
+If firmware or any component reports its own patch level, a compromised version can simply lie. Verification must use cryptographically signed external sources. Self-reporting reintroduces the exact trust assumption attestation was designed to eliminate.
+
+### Attestation must prove freshness, not just identity
+Without a session-specific nonce or equivalent, valid attestation reports can be replayed indefinitely, turning a one-time compromise into persistent impersonation.
+
+## Complementary Techniques Worth Considering
+
+Attestation and measurement are the foundation, but a full security solution usually layers in additional techniques:
+
+- **RA-TLS (Remote Attestation TLS)**: Combines attestation with encrypted communication so a client can verify what code is running on the server and establish a secure channel in one step.
+- **Anonymous routing**: Decouples requests from user identity so even if someone observes traffic patterns, they can't tie a specific request back to a specific user.
+- **Transparency logs**: Append-only records (often hosted by a third party) of every software artifact running in the system. The client won't connect unless the server proves it's running code that matches what's been logged. Changes can't be made silently.
+- **Ephemeral, stateless processing**: No data is retained after a request is handled. There's no history to leak, subpoena, or compromise later.
+- **In-app transparency reports**: Letting users see what happened to their data is a design pattern worth noting — it gives users visibility without requiring technical sophistication.
+
+## For Builders
+
+Treat these as a threat-model checklist:
+
+- What sits outside your measured boundary?
+- Are any inputs loaded post-measurement?
+- Is firmware and platform state verified cryptographically?
+- Is attestation bound to a specific session?
+
+If you can't answer clearly, your TEE story is weaker than you think.
+
+## For Enterprise Buyers
+
+Go beyond "do you use TEEs?" and ask:
+
+- What exactly is measured?
+- What sits outside the attestation boundary?
+- How are firmware and patch state verified?
+- How is replayed attestation prevented?

--- a/docs/core/tees-in-practice.md
+++ b/docs/core/tees-in-practice.md
@@ -1,0 +1,80 @@
+---
+title: TEEs in Practice
+parent: Core Concepts
+nav_order: 9
+---
+
+# TEEs in Practice
+
+## The Big Picture
+
+TEEs are emerging as a practical trust layer across crypto infrastructure and AI agent systems. They're not trustless, but they meaningfully shrink exposure by providing hardware-backed isolation, remote attestation, and constrained key handling. Think of them as a bridge — useful now while stronger cryptographic guarantees (ZK, PIR, MPC) mature.
+
+## What TEEs Actually Provide
+
+- **Isolated execution** where even a privileged host operator can't read plaintext memory
+- **Remote attestation** so clients can verify what code is running before releasing secrets
+- **Code integrity via measurement** to detect tampering
+- **Verifiable runtime identity** — especially valuable for services like MCP servers that currently have no strong way to prove what's running behind an endpoint
+- **Coordination without full consensus overhead** — they don't replace consensus, they change *when* it's needed
+
+## Real-World Examples
+
+- **Coinbase (Nitro Enclaves)**: Enforces signing policies *inside* the enclave rather than at the API perimeter. This matters especially as autonomous agents begin initiating transactions — the policy and the key live in the same trust boundary.
+- **Flashbots (SGX)**: Uses SGX for confidential block building in MEV, with commendable transparency about the tradeoffs (side-channel risks, reproducible build complexity).
+- **Vitalik's framing**: TEEs as a near-term privacy fix for RPC and read-path privacy, while stronger cryptographic methods like PIR mature.
+
+## The Agent Commerce Angle
+
+When paired with protocols like **x402** (machine-to-machine HTTP-native payments), TEEs form an emerging stack:
+
+- **x402** handles *how* agents pay
+- **TEEs** constrain *how keys authorize* those payments
+- **Attestation** verifies *where* that logic runs
+
+## AI Agents and MCP Servers
+
+Remote MCP servers are an urgent and underappreciated case. A single MCP process typically aggregates multiple high-value credentials — GitHub tokens, database connection strings, AWS keys, Slack tokens — all in one address space. Existing controls don't cover this:
+
+- **IAM** authorizes API calls, not memory reads
+- **Secrets vaults** protect data at rest but not in use
+- **Container isolation** doesn't defend against privileged host operators
+- **Network policies** are irrelevant when credentials can be read directly from process memory
+
+TEEs close this infrastructure gap, but in practice they call for a **two-layer credential model**:
+
+1. **Baseline service credentials** are provisioned at deployment through attestation-to-key-vault flows.
+2. **Agent-sent scoped tokens** (user OAuth, STS credentials) are only released after the agent verifies the server's attestation.
+
+The TEE protects both layers from host-level extraction.
+
+## Limits
+
+TEEs are not a silver bullet. A reasonable rule across both crypto and AI: use TEEs to reduce exposure windows and protect confidentiality, never as the sole trust guarantee.
+
+- **In crypto**: side-channel attacks, implementation bugs, supply-chain risks, and vendor trust remain real.
+- **In AI**: prompt injection, sampling attacks, and tool poisoning are application-layer threats that hardware isolation can't touch.
+
+## Where It's Heading
+
+The architecture is evolving toward hybrid models — TEE execution verified or audited with ZK techniques, gradually migrating trust from hardware to cryptography over time without waiting for perfect solutions.
+
+## Open Problems
+
+Common across crypto and AI:
+
+- **Multi-party attestation** across chained services (MCP servers, MEV pipelines)
+- **Dynamic capability delegation** where LLMs or agents grant scoped access
+- **Attestation-aware transport protocols**
+- **Confidential observability** for SOC teams
+- **Long-term migration** from hardware trust roots to cryptographic verifiability
+
+## The Builder's Mindset That Wins
+
+The right sequencing differs by domain, but the throughline is the same: ship useful systems now, document trust assumptions honestly, and design for eventual compromise.
+
+- **In crypto**: ship with TEEs now, expose assumptions clearly, and build migration paths toward stronger cryptographic guarantees (hybrid TEE + ZK).
+- **In AI**: ship the capability model first (default-deny permissions, scoped tokens, confirmation gates for writes), then layer TEEs on top to close the host-trust gap.
+- **In both**: plan for key rotation, revocation, and forensic observability from day one.
+
+Ideological purity — whether "fully trustless" in crypto or "we have IAM" in AI — loses to operational accountability.


### PR DESCRIPTION
## Summary
- New `docs/core/tee-security-principles.md` — prescriptive page covering attestation-boundary completeness (measuring all inputs, hardware config like ACPI tables, firmware self-reporting, attestation freshness), builder/enterprise-buyer checklists, and complementary techniques (RA-TLS, anonymous routing, transparency logs, ephemeral processing, in-app transparency reports).
- New `docs/core/tees-in-practice.md` — applied page covering what TEEs actually provide, real-world examples (Coinbase Nitro, Flashbots SGX, Vitalik on RPC privacy), the agent commerce stack (x402 + TEEs + attestation), AI agents and MCP servers (credential aggregation + two-layer credential model), limits split by crypto vs. AI domain, open problems, and builder's mindset.

## Test plan
- [ ] `bundle exec jekyll serve` renders both pages under Core Concepts
- [ ] Nav order places principles (8) and practice (9) after existing Core Concepts pages
- [ ] Internal links and headings render correctly under just-the-docs theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)