### PR TITLE
Add Intel TDX page; expand Live Migration with strategies, limits, and ops

### DIFF
--- a/docs/core/live-migration.md
+++ b/docs/core/live-migration.md
@@ -6,7 +6,7 @@ nav_order: 7
 
 # Live Migration
 
-Migration — moving a running workload from one physical machine to another — is useful for several reasons. It enables **load balancing** for long-lived jobs, where you can shift work off an overloaded server (a natural question: why not short-lived jobs too? Probably because they'll finish before migration pays off). It gives you **controlled maintenance windows** instead of emergency ones, since you can move work off a machine before taking it down. It supports **fault tolerance** by letting you move jobs away from hardware that's getting flaky but hasn't failed yet. And it helps with **energy efficiency** — you can consolidate loads onto fewer machines to reduce cooling (A/C) needs. The data center is the natural environment for all of this, since you have many machines under unified control.
+Migration — moving a running workload from one physical machine to another — is useful for several reasons. It enables **load balancing** for long-lived jobs, where you can shift work off an overloaded server (a natural question: why not short-lived jobs too? Probably because they'll finish before migration pays off). It gives you **controlled maintenance windows** instead of emergency ones, since you can move work off a machine before taking it down. It supports **fault tolerance** by letting you move jobs away from hardware that's getting flaky but hasn't failed yet. It helps with **energy efficiency** — you can consolidate loads onto fewer machines to reduce cooling (A/C) needs. And it supports **operator-driven placement** — moving a VM to a different host or host group (shared to dedicated, rebalancing a noisy-neighbor situation) without restarting the workload. The data center is the natural environment for all of this, since you have many machines under unified control.
 
 ## The spectrum of migration approaches
 
@@ -38,7 +38,14 @@ Non-live VMM migration (where the VM is suspended, moved, and resumed) is also u
 
 ## Goals of live migration
 
-Live migration has three goals in tension with each other: minimize downtime (the window where the service is unavailable), keep total migration time manageable, and limit the impact on both the VM being moved and the local network during the move.
+Live migration optimizes four things at once, and they pull against each other:
+
+- **Downtime** — the window where the service is unavailable. Should be short enough to be invisible to the workload.
+- **Total migration time** — wall-clock from start to finish.
+- **Total transferred bytes** — how much data goes over the network between source and destination.
+- **Impact on other services** — the migration consumes bandwidth and CPU on both hosts. Too aggressive and it starves neighbors; too conservative and total migration time blows out. **Throttling** (capping the migration's network and CPU usage) is the standard lever.
+
+No scheme minimizes all four. A short downtime needs a fast final copy, which eats bandwidth. Minimizing total transferred bytes (no re-copying) tends to mean a longer downtime. Every live migration algorithm is a particular choice among these trade-offs.
 
 The downtime target is more concrete than "users don't notice." Network protocols like TCP have timeouts on connections to external endpoints, and if the VM is unreachable longer than those timeouts, live connections break. A common target is keeping total pause time under **750 ms**, which stays below most common stack timeouts. This is why sub-second downtime matters — it's about preserving existing network connections, not just perceived responsiveness. (The 60 ms figure reported for a running Quake 3 game on early live migration work is well under this bar.)
 
@@ -53,16 +60,47 @@ Live migration proceeds in two named phases. **Brownout** is the period where th
     User-facing traffic keeps flowing during brownout, but **control-plane operations on the VM are typically blocked** — configuration changes, resize operations, and other admin actions are paused so the VM's definition doesn't shift underneath the migration.
 
     There's a design decision around **when** to enable dirty tracking. If tracking has a meaningful performance cost, you only turn it on at the start of brownout — accepting that the first iteration has to copy the entire memory image since nothing was tracked before. If tracking is cheap enough to run continuously, you enable it at VM startup; then the first brownout iteration already knows which pages are dirty and can skip the clean ones. For workloads that dirty memory slowly (e.g., CPU-heavy VMs that barely touch most of RAM), that's a big win.
-4. **Stop and copy the remainder (blackout).** Pause the VM on the source and copy the last bit of dirty state. This is the only window where the service is actually down. At the end of this step, the source and destination are identical — either could be restarted. Once the destination acknowledges the copy, the migration is committed (in the database transaction sense — it's officially done and can't be half-finished).
+4. **Stop and copy the remainder (blackout).** Pause the VM on the source and copy the last bit of dirty state. This is the only window where the service is actually down. At the end of this step, the source and destination are identical — either could be restarted. Once the destination acknowledges the copy, the migration is committed (in the database transaction sense — it's officially done and can't be half-finished). One subtle effect: wall-clock time keeps advancing while the VM is paused, so the guest clock appears to jump forward on resume. Long enough blackouts need a guest-side daemon to resync.
 5. **Redirect the network.** Send a "gratuitous ARP" packet — essentially an unsolicited announcement to the local network saying "this IP address now lives at this new MAC address" — so traffic starts arriving at the new host. A few packets in flight may be lost, but that kind of packet loss happens on normal networks anyway, and TCP will retransmit and recover.
-6. **Resume on the new host.** The VM starts running again on the destination.
+6. **Resume on the new host (target brownout).** The VM starts running again on the destination. The source may still provide temporary support — forwarding stray packets until the network fabric catches up with the new location.
 7. **Delete the source.** Tear down the original VM on the source host. No residual dependencies — the old host is completely free.
 
 The two numbers to watch when a migration runs long are **blackout duration** and **dirty-page count**. High dirty-page counts point to workload pressure — the VM is writing memory fast enough that brownout iterations can't shrink. Long blackouts with modest dirty-page counts point to network pressure — the final copy is slow because bandwidth between source and target is the bottleneck, not the amount of data.
 
+## Memory-copy strategies
+
+The algorithm above is called **pre-copy** — transfer memory while the VM keeps running, then pause briefly to catch up. It isn't the only option. There are three main strategies, each making a different choice among the trade-offs:
+
+- **Pre-copy.** The canonical algorithm: iteratively copy memory from source to destination while the VM runs on the source, then pause for a final catch-up. Easy to implement, no fast inter-host network required, present in most mainstream hypervisors (Xen, KVM, VMware ESX). Convergence depends on the copy rate outpacing the VM's memory write rate; if the VM dirties pages faster than they can be sent, the iterations never shrink and you have to cut over without convergence.
+- **Post-copy.** Reverses the order. Suspend the source, copy a minimal slice of execution state (CPU registers, critical device state) to the destination, immediately transfer execution, then fetch pages on demand. Any access to an un-transferred page triggers a fault that's redirected back to the source over the network. Each page is sent at most once, so **total transferred bytes is minimized** — but the destination depends on the source throughout the copy, page faults add latency, and a network hiccup can stall the VM. (TDX live migration uses this model for its final memory phase — see below.)
+- **Hybrid.** Run some pre-copy iterations first, then cut over to post-copy. The pre-copy warm-up reduces the chance of page faults after execution transfers, trading total migration time against worst-case latency.
+
 ## Variants
 
-There are a few flavors of live migration. **Managed migration** moves the OS without its cooperation — the VMM does everything from outside, and the guest OS doesn't even know it's happening. **Managed migration with paravirtualization** is the same thing but with the guest OS pitching in on specific optimizations: for instance, *stunning* (briefly freezing) rogue processes that are dirtying memory too fast to keep up with, or pushing unused memory pages out of the VM so they don't need to be copied at all. ("Paravirtualization" means the guest OS is modified to cooperate with the VMM, rather than being unaware of it.) **Self migration** goes further: the OS itself drives the migration. This is harder because you're trying to snapshot a running OS using that same OS — it's like trying to take a photo of yourself taking the photo.
+There are a few flavors of live migration, orthogonal to the memory-copy strategy above. **Managed migration** moves the OS without its cooperation — the VMM does everything from outside, and the guest OS doesn't even know it's happening. **Managed migration with paravirtualization** is the same thing but with the guest OS pitching in on specific optimizations: for instance, *stunning* (briefly freezing) rogue processes that are dirtying memory too fast to keep up with, or pushing unused memory pages out of the VM so they don't need to be copied at all. ("Paravirtualization" means the guest OS is modified to cooperate with the VMM, rather than being unaware of it.) **Self migration** goes further: the OS itself drives the migration. This is harder because you're trying to snapshot a running OS using that same OS — it's like trying to take a photo of yourself taking the photo.
+
+## What's hard to migrate live
+
+The approach works because VM state — memory, registers, a few device queues — can be captured and reconstituted elsewhere. State that doesn't fit that model is where live migration breaks down:
+
+- **Passthrough devices.** When a VM has direct access to a physical device (GPU, FPGA, SR-IOV NIC), the device's internal state lives in hardware the hypervisor doesn't control. There's no clean way to snapshot "what the GPU was in the middle of" and replay it on a different physical chip.
+- **Hardware-bound identifiers.** Anything tied to a specific physical machine — serial numbers, TPM state bound to the host's endorsement key, hardware-rooted secrets — has to be re-established on the destination or the migration can't preserve it.
+- **Tight latency budgets.** Workloads that can't absorb even a brownout, let alone the blackout, aren't good candidates. Terminate-and-restart on a planned window may be the cleaner answer.
+
+Platforms handle these by refusing live migration for the affected VM class, giving advance notice so the workload can drain or checkpoint, or offering a paravirtualized equivalent whose state is capturable.
+
+## Operational concerns
+
+An individual migration is only half the story. At fleet scale there's a separate scheduling layer — cluster management software that decides when and which VMs migrate. It watches for trigger events (hardware-failure signals, planned maintenance, firmware rollouts, explicit operator requests), schedules migrations against policies (caps on concurrent migrations per customer, capacity limits on target hosts, fairness across tenants), and paces the fleet so a failing rack doesn't stampede the rest of the data center.
+
+Not every VM runs in "always migrate" mode. Platforms typically expose a per-VM **availability policy**:
+
+- **Maintenance behavior** — live-migrate (default) or terminate on an event. Termination suits workloads that need constant peak performance (no brownout acceptable) or apps that already handle instance failures.
+- **Restart behavior** — whether a terminated VM comes back automatically or waits for manual restart.
+
+The choice is whether the app prefers degraded-but-continuous (brownout) or clean-but-offline (terminate-and-restart).
+
+Live migration demands the same rigor as any other critical infrastructure. **Fault injection** at each interesting point in the algorithm (network drops mid-copy, destination crash during blackout, source crash after commit) verifies the system either completes the migration or cleanly aborts. A **simulated maintenance event API** lets workload owners trigger a migration on demand against their own VMs, so they can confirm their availability policies behave the way they expect.
 
 ## Hyper-V
 

--- a/docs/core/live-migration.md
+++ b/docs/core/live-migration.md
@@ -70,4 +70,93 @@ _Notes to come._
 
 ## TDX Live Migration
 
-_Notes to come._
+Intel TDX v1.5 adds live migration on top of the TDX v1.0 confidential-VM machinery described in [Intel TDX](tdx.md). The same brownout/blackout shape from the generic case still applies — what changes is who can see the state in transit.
+
+### Why it's harder under TDX
+
+In legacy VMM migration, the host VMM is trusted and has full access to VM memory and state, so source and destination VMMs handle verification, authentication, and transport directly. Under TDX, the host VMM is **untrusted** and cannot read TD memory or state at all. Every byte of migration data has to flow through the TDX Module, encrypted and integrity-protected. This forces two additional components with no legacy equivalent: a **Migration TD (migTD)** that brokers trust between platforms, and a set of **TDX Module migration APIs** that package and unpackage state.
+
+### Roles
+
+| Role | Description |
+|---|---|
+| **Target TD (tgtTD)** | The TD being migrated. It is *unaware* migration is happening and performs no special actions. |
+| **Source TD (srcTD)** | The tgtTD while running on the source platform. |
+| **Destination TD (dstTD)** | A template TD constructed on the destination platform to receive migration data. |
+| **Migration TD (migTD)** | A special TD created on *both* platforms to verify attestation and exchange cryptographic keys. Bound to the tgtTD before its measurements are finalized. |
+| **Source/Destination VMM** | The host VMMs on each platform. They coordinate the transfer but are untrusted and cannot see TD data. |
+
+Although migration is designed for cross-platform relocation, the operations can technically take place on a single platform.
+
+### Bundles, session keys, and attestation
+
+All TD state transferred during migration is packaged into **migration bundles** — units of private memory or non-memory state that are both encrypted and integrity-protected under AES-GCM-256 using a **Migration Session Key (MSK)**. The TDX Module generates the MSK; the migTDs on each platform exchange MSKs with each other, and the destination migTD installs the key into the dstTD.
+
+Before migration proceeds, the migTDs examine each other's TDX Module capabilities and attestation evidence and check them against a **migration policy** that specifies acceptable TD attributes, allowed SVNs, and supported migration protocol versions. This is what extends TDX's confidentiality and integrity guarantees across platforms: the dstTD only accepts state that comes from a TDX Module the migTD has vouched for.
+
+### Migration Stream Contexts
+
+Some migration steps — decrypting bundles, importing metadata — are time-consuming. The TDX Module checks for pending hardware interrupts during these operations and, if one arrives, saves progress to a **Migration Stream Context (MigSC)**, returns control to the VMM, and later resumes from where it left off — verifying that no conflicting operations occurred in the interim. This keeps the untrusted VMM responsive without giving it a window to tamper with in-flight state.
+
+### Phases
+
+The migration walks the dstTD through a sequence of operation states, paralleling the normal build sequence but sourced from bundles rather than from the VMM directly.
+
+1. **Setup.** The destination VMM creates a template dstTD (allocate → configure encryption → add control structures, the same common setup as a normal build). A migTD is created on both platforms and bound to the target TD. Migration Stream Contexts are created, and the migTDs exchange Migration Session Keys.
+2. **Immutable state import.** The dstTD's immutable state — the equivalent of what the normal build's initialization step sets up — is imported from encrypted bundles. Interruption and resumption via MigSCs is supported. On completion, the TD enters the **Memory Import** operation state.
+3. **In-order memory import (brownout).** The srcTD *continues running*. Memory pages are exported from the source, encrypted into bundles, and imported into the dstTD where they are decrypted and verified (attributes and location must match between source and destination). Order is critical: if the same page is exported multiple times because the srcTD modified it, imports must happen oldest-first, newest-last so the final state is correct.
+4. **Blackout begins.** The Intel TDX-imposed blackout starts: the srcTD is *stopped*. Mutable TD-scope state (registers, control structures, other runtime state that changes while the TD runs) can only be exported during this blackout. That state is imported into the dstTD, which enters the **State Import** operation state.
+5. **VP state and dirty-page migration.** With the srcTD stopped, per-VP state is imported and any pages dirtied during brownout are re-migrated. Memory import continues in parallel. **Epoch tracking** manages the transition out of this phase: the source creates migration epoch tokens and the destination consumes them; when the final (start) token arrives, the TD enters **Post-Import**.
+6. **Out-of-order memory import (post-copy).** The srcTD is no longer runnable and page ordering no longer matters, so memory can be imported in any order. Once the import is committed, **the blackout ends and the dstTD can start running — even before all memory pages have arrived.** If the dstTD accesses a page that hasn't transferred yet, an EPT violation fires and the destination VMM can prioritize that page. The rest stream in in the background. When all memory is transferred and the migration is finalized, the TD returns to the **Runnable** state.
+
+Shared (non-private) memory is handled separately through traditional VMM workflows, outside the TDX Module.
+
+### Operation-state flow
+
+```
+              ┌─────────────────────────────────────────┐
+              │          COMMON SETUP                   │
+              │  Allocate TD → Configure Encryption     │
+              │  → Add Control Structures               │
+              └──────────────┬──────────────────────────┘
+                             │
+              ┌──────────────┴──────────────┐
+              │                             │
+         BUILD PATH                    IMPORT PATH
+              │                             │
+     Initialize TD state          Bind migTD, create
+              │                   streams, exchange keys
+              ▼                             │
+        INITIALIZED               Import immutable state
+              │                             │
+     Create VPs, populate                   ▼
+     memory, measure                 MEMORY IMPORT
+              │                   (srcTD still running,
+     Finalize measurements         in-order page import)
+              │                             │
+              │                   Stop srcTD (blackout),
+              │                   import mutable TD state
+              │                             │
+              │                             ▼
+              │                      STATE IMPORT
+              │                   (VP state, dirty pages,
+              │                    epoch tracking)
+              │                             │
+              │                             ▼
+              │                      POST-IMPORT
+              │                   (out-of-order pages,
+              │                    no ordering needed)
+              │                             │
+              │                   Commit → blackout ends
+              │                   → dstTD can run
+              │                             │
+              │                             ▼
+              │                      LIVE IMPORT
+              │                   (post-copy, dstTD running,
+              │                    remaining pages transfer)
+              │                             │
+              │                   Finalize migration
+              │                             │
+              ▼                             ▼
+                        RUNNABLE
+```

--- a/docs/core/tdx.md
+++ b/docs/core/tdx.md
@@ -1,0 +1,55 @@
+---
+title: Intel TDX
+parent: Core Concepts
+nav_order: 8
+---
+
+# Intel TDX
+
+Intel Trust Domain Extensions (TDX) is Intel's VM-level confidential computing technology. It protects whole virtual machines — called **Trust Domains (TDs)** — from a potentially malicious host environment, in contrast to SGX, which protects individual enclaves within a process.
+
+## Threat model
+
+TDX assumes the attacker has privileged control of the hypervisor/VMM, the host OS, BIOS, System Management Mode, legacy VMs, other TDs, and any other non-TD software. Despite this, TDX guarantees **confidentiality** (no unauthorized entity can read TD data) and **integrity** (no unauthorized entity can tamper with TD data). **Availability is explicitly excluded** — the host VMM can always deny a TD platform resources.
+
+## Architectural components
+
+**SEAM (Secure Arbitration Mode)** is a CPU execution mode that hosts the TDX Module. It is isolated from the host VMM, other system software, and device DMA by a reserved memory region defined by the **SEAM Range Register (SEAMRR)**. New x86 instructions let the host VMM call into the TDX Module (the "Host Interface") and let guest TDs call in (the "Guest Interface").
+
+The **Intel TDX Module** is the core runtime firmware running inside SEAM. It enforces all TD security guarantees — managing TD lifecycle, memory encryption, page-table integrity, and (in v1.5) migration operations.
+
+**TME-MK (Total Memory Encryption, Multi-Key)** provides per-TD memory encryption and integrity. Each TD is assigned a **Host Key Identifier (HKID)**, and the TDX Module programs a unique private encryption key for that HKID into hardware. Only the TDX Module and the owning TD can access the encrypted memory.
+
+**MCHECK** is a closed-source microcode component that runs at boot. It verifies platform configuration (correct SEAMRR setup, convertible memory ranges), stores configuration data securely inside SEAMRR, and validates that all cores and packages provide compatible CPU features.
+
+The **SEAM Loaders** form a two-stage loading chain: the Non-Persistent SEAM Loader (NP-SEAMLDR) is an Authenticated Code Module that verifies and loads the Persistent SEAM Loader, which in turn verifies and loads or updates the TDX Module itself.
+
+## Attestation
+
+TDs can generate **local attestation reports (TDReports)** containing platform configuration and software measurements. An Intel SGX enclave (the TDQuoting Enclave) signs these to produce **remote attestation reports (TDQuotes)**. Attestation lets external parties verify a TD's execution environment; during Live Migration, it also establishes mutual trust between source and destination TDX Modules. Intel provides infrastructure to verify that a TDQuote came from genuine hardware, but **customers are responsible for verifying report content** against their own security policy.
+
+## SVNs and TCB recovery
+
+Every TCB component (TDX Module, SEAM Loaders, CPU hardware) carries a **Security Version Number (SVN)**, embedded in attestation reports and checked at startup against minimum thresholds. When a vulnerability is fixed, the SVN is incremented. **TCB Recovery (TCB-R)** is the process that causes older, vulnerable versions to be flagged as insecure through attestation so that relying parties stop trusting them.
+
+## TD state machines
+
+The TDX Module tracks each TD using two primary state machines, plus per-page state.
+
+**Lifecycle state** lives in the **Trust Domain Root (TDR)** and tracks the high-level resource lifecycle: *HKID Assigned* (initial state after creation) → *Keys Configured* (encryption keys programmed — where the TD spends most of its life) → *Blocked* (resources being reclaimed) → *Teardown* (final teardown).
+
+**Operation state** lives in the **TD Control Structure (TDCS)** and controls which operations are permitted at any given time. It is the primary gating mechanism for API access and is the more complex of the two machines. Key states include *Initialized*, *Runnable*, and several migration-specific states (see [Live Migration](live-migration.md#tdx-live-migration)).
+
+**Secure EPT entry state** is carried per-entry in the Secure Extended Page Table (SEPT), ensuring that page-level operations (reads, writes, migrations) only happen when the entry is in an acceptable state for that operation.
+
+## TD build sequence
+
+Building a TD from scratch follows a structured sequence:
+
+1. **Allocate and assign.** A root page is allocated for the TD and a unique HKID is assigned.
+2. **Configure encryption.** The HKID and its private encryption key are programmed into TME-MK.
+3. **Add control structures.** Multiple pages are added and initialized for the TD's internal control structures.
+4. **Initialize TD state.** Global-scope state is initialized: CPUID configuration, virtualization controls, MSR bitmaps, measurement fields, and nested-VM settings. Data comes from both the TDX Module's internal structures and parameters supplied by the host VMM. After this step the TD enters the **Initialized** operation state.
+5. **Create Virtual Processors.** One or more VPs are created and initialized with their own control-structure pages. This can happen in any order and from any logical processor.
+6. **Populate memory.** The Secure EPT paging hierarchy is built and private memory pages are added with their contents. Each page's contents are incorporated into the TD's measurement.
+7. **Finalize.** Measurements are locked. The TD enters the **Runnable** operation state and can begin executing.


### PR DESCRIPTION
## Summary
- New **Intel TDX** core-concepts page covering architecture (SEAM, TDX Module, TME-MK, MCHECK, SEAM Loaders), attestation, SVNs/TCB-R, state machines, and the TD build sequence.
- Replaces the **TDX Live Migration** placeholder with TDX-specific content: migTD trust model, migration bundles and session keys, Migration Stream Contexts, the phased import flow, and the operation-state diagram.
- Expands the generic **Live Migration** page with material that was missing: pre-copy/post-copy/hybrid memory strategies, what resists live migration (passthrough devices, hardware-bound identifiers, tight latency budgets), and fleet-scale operational concerns (scheduling layer, per-VM availability policy, fault injection, simulated maintenance events).
- Smaller additions: operator-driven placement as a motivation, total transferred bytes and throttling as a fourth trade-off axis, guest clock jump after long blackouts, target-side brownout.

## Test plan
- [ ] Build the Jekyll site locally and confirm the new \`Intel TDX\` page renders under Core Concepts (nav_order 8).
- [ ] Confirm the \`Live Migration\` page renders with the new \`Memory-copy strategies\`, \`What's hard to migrate live\`, and \`Operational concerns\` sections, and that the \`TDX Live Migration\` section is populated.
- [ ] Verify cross-link from \`tdx.md\` to \`live-migration.md#tdx-live-migration\` resolves.