### PR TITLE
Improve README with dev setup, contributing guide, and accurate structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,41 +6,88 @@
 [![GitHub forks](https://img.shields.io/github/forks/ksayid/confidential-computing-notes?style=social)](https://github.com/ksayid/confidential-computing-notes/network)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](https://github.com/ksayid/confidential-computing-notes/issues)
 
-This repository contains my personal notes, resources, and explorations related to confidential computing. I've organized these learnings into Markdown files focusing on key concepts and technologies powering confidential computing in the cloud. By organizing this knowledge in a single place, I can track my growth and hopefully help others explore confidential computing.
+A structured, open-source knowledge base on confidential computing — covering trusted execution environments, attestation, Intel TDX/SGX, confidential containers, and cloud security.
 
-Some topics include:
-* Trusted Execution Environments
-* Confidential Containers/VMs
-* Kubernetes
-* Attestation Protocols
+## Why This Exists
+
+Confidential computing is a fast-moving field spread across vendor docs, academic papers, and specification PDFs. This site distills those sources into a single, searchable reference organized by topic — so you can understand how TEEs, attestation, and confidential containers actually work without piecing it together yourself.
 
 > [!NOTE]
 > All opinions and explanations in this repo are my own and do not necessarily reflect the official stance of my employer.
 
-## What is Confidential Computing?
-Confidential Computing is all about protecting sensitive data while in use. It leverages hardware-based Trusted Execution Environments (TEEs) to ensure data, application code, and machine learning models remain secure even when attackers have full privileges on a system. As enterprise data moves off-premises into the cloud, confidential computing is becoming a crucial part of building zero-trust architectures.
+## What's Covered
+
+### [Core Concepts](https://ksayid.github.io/confidential-computing-notes/docs/core/)
+Foundational topics including confidential computing principles, TEE security models, Intel SGX enclaves, Intel TDX (overview, architecture, ABI, trusted I/O), encrypted filesystems, secure key release, paravisors, and live migration of confidential VMs.
+
+### [Container Technologies](https://ksayid.github.io/confidential-computing-notes/docs/containers/)
+Container fundamentals, Kata Containers, Confidential Containers (CoCo), and Kubernetes integration for running workloads inside TEEs.
+
+### [Tools & Frameworks](https://ksayid.github.io/confidential-computing-notes/docs/tools/)
+gRPC and Open Policy Agent as they relate to confidential computing infrastructure.
+
+### [Reference](https://ksayid.github.io/confidential-computing-notes/docs/misc/)
+Cloud fundamentals and supplementary notes.
+
+## Local Development
+
+The site is built with [Jekyll](https://jekyllrb.com/) using the [just-the-docs](https://just-the-docs.com/) theme and hosted on GitHub Pages.
+
+### Prerequisites
+
+- Ruby (with `gem`)
+- [Bundler](https://bundler.io/) (`gem install bundler`)
+
+### Setup
+
+```bash
+git clone git@github.com:ksayid/confidential-computing-notes.git
+cd confidential-computing-notes
+bundle install
+```
+
+### Run locally
+
+```bash
+bundle exec jekyll serve
+```
+
+Then open [http://localhost:4000](http://localhost:4000).
 
 ## Repository Structure
-Most site content lives under the `docs/` directory. Assets such as CSS and
-JavaScript remain at the repository root to avoid issues with GitHub Pages.
-Content is grouped by topic so new contributors can easily find the appropriate
-location.
 
 ```
 docs/
-├── core
-├── containers
-├── tools
-├── misc
-└── img
-_config.yml
-index.md
-search.md
-search.json
-assets/
-├── css
-└── js
+├── core/           # TEEs, SGX, TDX, attestation, key release, live migration
+├── containers/     # Kata, CoCo, Kubernetes, container fundamentals
+├── tools/          # gRPC, Open Policy Agent
+├── misc/           # Cloud fundamentals, scratch notes
+└── img/            # Architecture diagrams
+_config.yml         # Jekyll configuration (theme, search, navigation)
+_sass/              # Custom style overrides
+index.md            # Site homepage
+```
+
+## Contributing
+
+Contributions are welcome — whether it's fixing a typo, improving an explanation, or adding a new topic.
+
+1. Fork the repository
+2. Create a branch (`git checkout -b my-topic`)
+3. Add or edit Markdown files under `docs/` in the appropriate section
+4. Test locally with `bundle exec jekyll serve`
+5. Open a pull request
+
+Each content page uses [just-the-docs front matter](https://just-the-docs.com/docs/navigation-structure/) for navigation:
+
+```yaml
+---
+title: Page Title
+parent: Core Concepts    # must match the parent index title
+nav_order: 5
+---
 ```
 
 ## License
+
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Add local development instructions (Ruby/Bundler prerequisites, `bundle install`, `jekyll serve`)
- Add contributing guidelines with step-by-step workflow and front matter examples
- Rewrite topic overview to reflect all 26 pages of content (TDX, SGX, paravisors, live migration, etc.)
- Fix outdated repository structure diagram (remove non-existent `assets/`, `search.md`, `search.json`; add `_sass/`, `index.md`)
- Sharpen the one-liner and add a "Why This Exists" section

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all links point to valid pages on the live site
- [ ] Run `bundle exec jekyll serve` locally to verify instructions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)